### PR TITLE
mount: add support for automatically mounting a mount

### DIFF
--- a/doc/getting-started.adoc
+++ b/doc/getting-started.adoc
@@ -36,7 +36,7 @@ v0:
     browser:
       if: true
       command: "!$BROWSER"
-  9p:
+  fs:
     default:
       if: true
       location: '!printf "%%s/.local/share/remote-files" "$HOME"'
@@ -57,8 +57,8 @@ user@remote:~ $ echo 'Hello, world!' | lawn clip -i
 # Paste something from the clipboard.
 user@remote:~ $ lawn clip -o
 Hello, world!
-# Mount the 9P mount default on ~/mnt/lawn.
-user@remote:~ $ lawn mount --fd default -- sudo mount -t 9p -o trans=fd,rfdno=0,wfdno=1,uname=bmc default ~/mnt/lawn &
+# Mount the SFTP mount default on ~/mnt/lawn (requires sshfs).
+user@remote:~ $ lawn mount --type=sftp --auto default ~/mnt/lawn &
 # Create a file that will be persisted to ~/.local/share/remote-files/hello on the local machine.
 user@remote:~ $ echo 'Hello, world!' > ~/mnt/lawn/hello
 ----
@@ -137,7 +137,8 @@ If you're using X11, you can also specify `-b` for the `CLIPBOARD` selection (wh
 
 Let's also consider one final thing we might want to set up: a file system mount.
 Perhaps we'd like to save our shell history across machines.
-We can do this using the 9P protocol, which was originally developed for the operating system Plan 9.
+We can do this using the 9P protocol, which was originally developed for the operating system Plan 9, or the SFTP protocol.
+The SFTP protocol is usually easier to work with and only requires FUSE access instead of root privileges, so it's preferred.
 
 First, let's create a space for our files on the local machine with `mkdir -p ~/.local/share/remote-files`.
 Then, we can create a place to mount our data with `mkdir -p ~/mnt/lawn`.
@@ -155,7 +156,7 @@ v0:
     browser:
       if: true
       command: "!$BROWSER"
-  9p:
+  fs:
     default:
       if: true
       location: '!printf "%%s/.local/share/remote-files" "$HOME"'
@@ -177,6 +178,20 @@ Lawn knows how to offer a Unix socket, but the Linux 9P implementation doesn't s
 Since the mount process will block until we unmount it, we run it in the background.
 
 We can now access `~/mnt/lawn` as if it were `~/.local/share/remote-files`.
+
+If we'd like to use the SFTP mount with `sshfs` instead, we can first unmount our 9P mount like so:
+
+[source,shell]
+----
+$ sudo umount ~/mnt/lawn
+----
+
+We can then mount using SSHFS automatically, with the following command:
+
+[source,shell]
+----
+$ nohup lawn mount --auto --type=sftp default ~/mnt/lawn &
+----
 
 Now that we've run these commands successfully on our local machine, we can also run them on a remote machine if we prefer.
 There are two ways to do this.

--- a/doc/man/lawn-mount.adoc
+++ b/doc/man/lawn-mount.adoc
@@ -6,7 +6,8 @@ lawn mount - provide access to a 9P file share
 
 == Synopsis
 
-'lawn mount' (--fd | --socket) <share>  -- <command> [<arg>…]
+'lawn mount' (--fd | --socket) [--type=<protocol>] <share>  -- <command> [<arg>…]
+'lawn mount' [--type=<protocol>] --auto <share> <mountpoint>
 
 == Description
 
@@ -36,6 +37,10 @@ These extensions and protocol version are supported by OpenSSH and sshfs.
   Create a Unix socket to provide access and expose it to the command via the environment variable `P9P_SOCKET` (for 9P) or `LAWN_SFTP_SOCKET` (for SFTP).
   The socket is destroyed when the command exits.
 
+`--auto`::
+  Automatically mount the share at the given mountpoint by invoking the proper program automatically.
+  This currently only works for SFTP mounts and requires a version of `sshfs` supporting `-o passive`.
+
 == Examples
 
 Assume we have the following configuration file:
@@ -57,3 +62,4 @@ Running `lawn mount --socket temp -- sh -c '9pfuse "unix!$P9P_SOCKET" ~/mnt/foo;
 Running `lawn mount --fd home -- sudo mount -t 9p -o trans=fd,rdfno=0,wfdno=1 home ~/mnt/home` on Linux will mount the `home` file share, which is located on the root machine at `$HOME`, to this machine at `~/mnt/home` using 9P.
 
 Running `lawn mount --fd --type=sftp home -- sshfs -o passive :/ ~/mnt/home` on Linux will mount the `home` file share, which is located on the root machine at `$HOME`, to this machine at `~/mnt/home` using SFTP.
+Exactly the same behaviour can be obtained with `lawn mount --type=sftp --auto home ~/mnt/home`.


### PR DESCRIPTION
With SFTP mounts, we know that usually the user will want to mount using SSHFS.  To make their life easier and reduce the need to look at the documentation, let's add an `--auto` option which automatically invokes the `sshfs` binary with the proper args.

In addition, let's update the getting started documentation to suggest this approach instead, as well as the documentation for `lawn mount`.