### PR TITLE
Improve channel performance

### DIFF
--- a/lawn-protocol/src/protocol/mod.rs
+++ b/lawn-protocol/src/protocol/mod.rs
@@ -124,7 +124,7 @@ impl ResponseCode {
     }
 }
 
-pub struct WrongTypeError;
+pub struct WrongTypeError(pub Error);
 
 #[derive(Debug, Clone)]
 pub struct Error {
@@ -172,7 +172,7 @@ impl TryInto<io::Error> for Error {
                 }
             }
         }
-        Err(WrongTypeError)
+        Err(WrongTypeError(self))
     }
 }
 

--- a/lawn/src/client.rs
+++ b/lawn/src/client.rs
@@ -253,7 +253,10 @@ impl Connection {
         }
     }
 
-    pub async fn run_clipboard<I: AsyncReadExt + Unpin, O: AsyncWriteExt + Unpin>(
+    pub async fn run_clipboard<
+        I: AsyncReadExt + Unpin + Send + 'static,
+        O: AsyncWriteExt + Unpin + Send + 'static,
+    >(
         self: Arc<Self>,
         stdin: I,
         stdout: O,
@@ -287,7 +290,10 @@ impl Connection {
         }
     }
 
-    pub async fn run_9p<I: AsyncReadExt + Unpin, O: AsyncWriteExt + Unpin>(
+    pub async fn run_9p<
+        I: AsyncReadExt + Unpin + Send + 'static,
+        O: AsyncWriteExt + Unpin + Send + 'static,
+    >(
         self: Arc<Self>,
         stdin: I,
         stdout: O,
@@ -305,7 +311,10 @@ impl Connection {
             .await
     }
 
-    pub async fn run_sftp<I: AsyncReadExt + Unpin, O: AsyncWriteExt + Unpin>(
+    pub async fn run_sftp<
+        I: AsyncReadExt + Unpin + Send + 'static,
+        O: AsyncWriteExt + Unpin + Send + 'static,
+    >(
         self: Arc<Self>,
         stdin: I,
         stdout: O,
@@ -324,9 +333,9 @@ impl Connection {
     }
 
     pub async fn run_command<
-        I: AsyncReadExt + Unpin,
-        O: AsyncWriteExt + Unpin,
-        E: AsyncWriteExt + Unpin,
+        I: AsyncReadExt + Unpin + Send + 'static,
+        O: AsyncWriteExt + Unpin + Send + 'static,
+        E: AsyncWriteExt + Unpin + Send + 'static,
     >(
         self: Arc<Self>,
         args: &[Bytes],
@@ -345,9 +354,9 @@ impl Connection {
     }
 
     async fn run_channel<
-        I: AsyncReadExt + Unpin,
-        O: AsyncWriteExt + Unpin,
-        E: AsyncWriteExt + Unpin,
+        I: AsyncReadExt + Unpin + Send + 'static,
+        O: AsyncWriteExt + Unpin + Send + 'static,
+        E: AsyncWriteExt + Unpin + Send + 'static,
     >(
         self: Arc<Self>,
         stdin: I,

--- a/lawn/src/error/mod.rs
+++ b/lawn/src/error/mod.rs
@@ -1,8 +1,9 @@
 use crate::fs_proxy;
 use lawn_protocol::{handler, protocol};
-use std::convert::TryFrom;
+use std::convert::{TryFrom, TryInto};
 use std::fmt;
 use std::fmt::Display;
+use std::io;
 
 #[derive(Debug)]
 pub struct Error {
@@ -139,6 +140,14 @@ impl TryFrom<Error> for protocol::Error {
             return Ok(e);
         }
         Err(WrongTypeError)
+    }
+}
+
+impl TryFrom<Error> for io::Error {
+    type Error = WrongTypeError;
+    fn try_from(e: Error) -> Result<io::Error, Self::Error> {
+        let err = protocol::Error::try_from(e)?;
+        err.try_into().map_err(|_| WrongTypeError)
     }
 }
 

--- a/lawn/src/error/mod.rs
+++ b/lawn/src/error/mod.rs
@@ -113,8 +113,8 @@ impl From<Error> for i32 {
     }
 }
 
-#[derive(Debug, Hash, Eq, PartialEq, Ord, PartialOrd)]
-pub struct WrongTypeError;
+#[derive(Debug)]
+pub struct WrongTypeError(pub Error);
 
 impl TryFrom<Error> for handler::Error {
     type Error = WrongTypeError;
@@ -123,11 +123,15 @@ impl TryFrom<Error> for handler::Error {
             ErrorKind::HandlerError => match e.cause {
                 Some(mut cause) => match cause.downcast_mut::<handler::Error>() {
                     Some(e) => Ok(std::mem::replace(e, handler::Error::Unserializable)),
-                    None => Err(WrongTypeError),
+                    None => Err(WrongTypeError(Error {
+                        kind: e.kind,
+                        cause: Some(cause),
+                        message: e.message,
+                    })),
                 },
-                None => Err(WrongTypeError),
+                None => Err(WrongTypeError(e)),
             },
-            _ => Err(WrongTypeError),
+            _ => Err(WrongTypeError(e)),
         }
     }
 }
@@ -139,7 +143,7 @@ impl TryFrom<Error> for protocol::Error {
         if let handler::Error::ProtocolError(e) = err {
             return Ok(e);
         }
-        Err(WrongTypeError)
+        Err(WrongTypeError(err.into()))
     }
 }
 
@@ -147,7 +151,8 @@ impl TryFrom<Error> for io::Error {
     type Error = WrongTypeError;
     fn try_from(e: Error) -> Result<io::Error, Self::Error> {
         let err = protocol::Error::try_from(e)?;
-        err.try_into().map_err(|_| WrongTypeError)
+        let e: Result<io::Error, _> = err.try_into();
+        e.map_err(|e| WrongTypeError(handler::Error::from(e.0).into()))
     }
 }
 

--- a/lawn/src/fs_proxy.rs
+++ b/lawn/src/fs_proxy.rs
@@ -122,7 +122,7 @@ impl Proxy {
     ) -> Proxy {
         let (rd, wr) = p9p.into_split();
         Proxy {
-            conn: Arc::new(Connection::new(config, None, ours, false)),
+            conn: Connection::new(config, None, ours, false),
             p9p_rd: rd,
             p9p_wr: wr,
             target,
@@ -154,11 +154,13 @@ impl Proxy {
         match self.protocol {
             ProxyProtocol::P9P => {
                 self.conn
+                    .clone()
                     .run_9p(&mut self.p9p_rd, &mut self.p9p_wr, self.target.clone())
                     .await?
             }
             ProxyProtocol::SFTP => {
                 self.conn
+                    .clone()
                     .run_sftp(&mut self.p9p_rd, &mut self.p9p_wr, self.target.clone())
                     .await?
             }

--- a/lawn/src/fs_proxy.rs
+++ b/lawn/src/fs_proxy.rs
@@ -80,7 +80,7 @@ impl ProxyListener {
                     let target = self.target.clone();
                     let protocol = self.protocol;
                     tokio::spawn(async move {
-                        let mut p = Proxy::new(config, conn, ours, target, protocol);
+                        let p = Proxy::new(config, conn, ours, target, protocol);
                         let _ = p.run_server().await;
                     });
                 }
@@ -95,7 +95,7 @@ impl ProxyListener {
                 if let Ok(ours) = UnixStream::connect(&self.ours).await {
                     let config = self.config.clone();
                     let target = self.target.clone();
-                    let mut p = Proxy::new(config, conn, ours, target, self.protocol);
+                    let p = Proxy::new(config, conn, ours, target, self.protocol);
                     let _ = p.run_server().await;
                     return Ok(());
                 }
@@ -147,7 +147,7 @@ impl Proxy {
         }
     }
 
-    pub async fn run_server(&mut self) -> Result<(), Error> {
+    pub async fn run_server(self) -> Result<(), Error> {
         self.conn.ping().await?;
         self.conn.negotiate_default_version().await?;
         self.conn.auth_external().await?;
@@ -155,13 +155,13 @@ impl Proxy {
             ProxyProtocol::P9P => {
                 self.conn
                     .clone()
-                    .run_9p(&mut self.p9p_rd, &mut self.p9p_wr, self.target.clone())
+                    .run_9p(self.p9p_rd, self.p9p_wr, self.target.clone())
                     .await?
             }
             ProxyProtocol::SFTP => {
                 self.conn
                     .clone()
-                    .run_sftp(&mut self.p9p_rd, &mut self.p9p_wr, self.target.clone())
+                    .run_sftp(self.p9p_rd, self.p9p_wr, self.target.clone())
                     .await?
             }
         };

--- a/lawn/src/main.rs
+++ b/lawn/src/main.rs
@@ -524,7 +524,7 @@ fn dispatch_mount(
                     );
                     loop {
                         if let Ok((req, _)) = psock.accept().await {
-                            let mut proxy = fs_proxy::Proxy::new_from_connection(
+                            let proxy = fs_proxy::Proxy::new_from_connection(
                                 config.clone(),
                                 req,
                                 conn.clone(),

--- a/lawn/src/main.rs
+++ b/lawn/src/main.rs
@@ -516,12 +516,12 @@ fn dispatch_mount(
                 }
                 ProxyType::ProxyFromBoundSocket(psock) => {
                     let _ = socket.set_nonblocking(true);
-                    let conn = Arc::new(Connection::new(
+                    let conn = Connection::new(
                         config.clone(),
                         None,
                         tokio::net::UnixStream::from_std(socket).unwrap(),
                         false,
-                    ));
+                    );
                     loop {
                         if let Ok((req, _)) = psock.accept().await {
                             let mut proxy = fs_proxy::Proxy::new_from_connection(

--- a/lawn/src/server.rs
+++ b/lawn/src/server.rs
@@ -728,7 +728,8 @@ impl Server {
                     None => return Err(ResponseCode::NotFound.into()),
                 };
                 let selector = m.selector;
-                let data = tokio::task::spawn_blocking(move || ch.read(selector))
+                let count = m.count;
+                let data = tokio::task::spawn_blocking(move || ch.read(selector, count))
                     .await
                     .unwrap()?;
                 let resp = protocol::ReadChannelResponse { bytes: data };

--- a/lawn/src/tests.rs
+++ b/lawn/src/tests.rs
@@ -133,7 +133,7 @@ v0:
         Arc::new(server::Server::new(self.config()))
     }
 
-    pub async fn connection(&self) -> client::Connection {
+    pub async fn connection(&self) -> Arc<client::Connection> {
         let client = Arc::new(client::Client::new(self.config()));
         let mut path = self.dir.path().to_owned();
         path.push("runtime/lawn/server-0.sock");


### PR DESCRIPTION
Currently, we attempt to poll all the selectors of the remote channel, and if they return that they're ready, we process all of the channels. However, this leads to a problem that we must poll in order to read or write, even if the remote side is constantly ready.

Instead, let's adjust our code to use implementations of the `AsyncRead` and `AsyncWrite` traits that simply read or write as much as possible until they return `EAGAIN`, only at which point do they poll.  This greatly simplifies our main loop, since all of the logic sits inside the read and write structs.

This may substantially improve performance of channels like SFTP because there's no longer any need to perform a needless round trip on every read and write.
