### PR TITLE
Improve round-trip speed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -48,9 +48,9 @@ checksum = "5988cb1d626264ac94100be357308f29ff7cbdd3b36bda27f450a4ee3f713426"
 
 [[package]]
 name = "bytes"
-version = "1.1.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
+checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
 dependencies = [
  "serde",
 ]

--- a/lawn-protocol/src/handler/mod.rs
+++ b/lawn-protocol/src/handler/mod.rs
@@ -1,6 +1,6 @@
 use crate::config::Config;
 use crate::protocol;
-use bytes::Bytes;
+use bytes::{Bytes, BytesMut};
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 use std::collections::{BTreeMap, BTreeSet, HashMap};
@@ -23,6 +23,16 @@ macro_rules! dump_packet {
         use crate::config::LogLevel;
         if $logger.level() <= LogLevel::Dump {
             $logger.trace(&format!("packet: {}", hex::encode($arg)));
+        }
+    }};
+    ($logger:expr, $header:expr, $body:expr) => {{
+        use crate::config::LogLevel;
+        if $logger.level() <= LogLevel::Dump {
+            $logger.trace(&format!(
+                "packet: {}{}",
+                hex::encode($header),
+                hex::encode($body)
+            ));
         }
     }};
 }
@@ -323,28 +333,31 @@ impl<T: AsyncRead + Unpin, U: AsyncWrite + Unpin> ProtocolHandler<T, U> {
         let logger = self.config.logger();
         // Hold the lock for the entire duration of reading the message so we don't read partial
         // messages.
-        let v = {
-            let mut buf = [0u8; 4];
+        let (header, body) = {
+            let mut buf = [0u8; 12];
             let mut g = self.inp.lock().await;
             g.as_mut().read_exact(&mut buf).await?;
-            let size: u32 = u32::from_le_bytes(buf);
+            let size: u32 = u32::from_le_bytes(buf[0..4].try_into().unwrap());
             if !self.serializer.is_valid_size(size) {
                 logger.trace(&format!("received invalid packet: size {:08x}", size));
                 return Err(Error::Undeserializable);
             }
-            let mut v: Vec<u8> = buf.into();
-            v.resize(size as usize + 4, 0);
-            g.as_mut().read_exact(&mut v[4..]).await?;
-            v
+            let mut b = BytesMut::new();
+            b.resize(size as usize - 8, 0);
+            g.as_mut().read_exact(&mut b).await?;
+            (buf, b.into())
         };
         logger.trace(&format!(
             "received packet: size {:08x} id {:08x} next {:08x}",
-            u32::from_le_bytes(v[0..4].try_into().unwrap()),
-            u32::from_le_bytes(v[4..8].try_into().unwrap()),
-            u32::from_le_bytes(v[8..12].try_into().unwrap())
+            u32::from_le_bytes(header[0..4].try_into().unwrap()),
+            u32::from_le_bytes(header[4..8].try_into().unwrap()),
+            u32::from_le_bytes(header[8..12].try_into().unwrap())
         ));
-        dump_packet!(logger, &v);
-        match self.serializer.deserialize_data(&self.config, &v)? {
+        dump_packet!(logger, &header, &body);
+        match self
+            .serializer
+            .deserialize_data(&self.config, &header, body)?
+        {
             protocol::Data::Message(m) => {
                 logger.trace(&format!(
                     "received message: id {:08x} kind {:08x}",

--- a/lawn-protocol/src/handler/mod.rs
+++ b/lawn-protocol/src/handler/mod.rs
@@ -329,7 +329,7 @@ impl<T: AsyncRead + Unpin, U: AsyncWrite + Unpin> ProtocolHandler<T, U> {
     ///
     /// Returns `Ok(Some(msg))` if the item read was a message, `Ok(None)` if it was a response
     /// (which we will handle automatically), and `Err` on error.
-    pub async fn recv(&self) -> Result<Option<protocol::Message>, Error> {
+    pub async fn recv(&self) -> Result<Option<Box<protocol::Message>>, Error> {
         let logger = self.config.logger();
         // Hold the lock for the entire duration of reading the message so we don't read partial
         // messages.
@@ -363,7 +363,7 @@ impl<T: AsyncRead + Unpin, U: AsyncWrite + Unpin> ProtocolHandler<T, U> {
                     "received message: id {:08x} kind {:08x}",
                     m.id, m.kind
                 ));
-                Ok(Some(m))
+                Ok(Some(Box::new(m)))
             }
             protocol::Data::Response(r) => {
                 logger.trace(&format!(

--- a/lawn-protocol/src/protocol/mod.rs
+++ b/lawn-protocol/src/protocol/mod.rs
@@ -6,9 +6,10 @@ use num_traits::FromPrimitive;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use serde_cbor::Value;
 use std::collections::{BTreeMap, BTreeSet};
-use std::convert::TryInto;
+use std::convert::{TryFrom, TryInto};
 use std::fmt;
 use std::io;
+use std::io::{Seek, SeekFrom};
 
 /// # Overview
 ///
@@ -669,8 +670,20 @@ impl ProtocolSerializer {
         (8..=Self::MAX_MESSAGE_SIZE).contains(&size)
     }
 
+    pub fn serialize_header(&self, id: u32, next: u32, data_len: usize) -> Option<Bytes> {
+        let size = data_len as u64 + 8;
+        if size > Self::MAX_MESSAGE_SIZE as u64 {
+            return None;
+        }
+        let mut b = BytesMut::with_capacity(size as usize);
+        let size = size as u32;
+        b.extend(&size.to_le_bytes());
+        b.extend(&id.to_le_bytes());
+        b.extend(&next.to_le_bytes());
+        Some(b.into())
+    }
+
     pub fn serialize_message_simple(&self, msg: &Message) -> Option<Bytes> {
-        let mut b = BytesMut::new();
         let size = 8 + match &msg.message {
             Some(m) => m.len(),
             None => 0,
@@ -678,6 +691,7 @@ impl ProtocolSerializer {
         if size > Self::MAX_MESSAGE_SIZE as usize {
             return None;
         }
+        let mut b = BytesMut::with_capacity(size);
         let size = size as u32;
         b.extend(&size.to_le_bytes());
         b.extend(&msg.id.to_le_bytes());
@@ -690,13 +704,22 @@ impl ProtocolSerializer {
     }
 
     pub fn serialize_message_typed<S: Serialize>(&self, msg: &Message, obj: &S) -> Option<Bytes> {
-        let mut m = msg.clone();
-        let body = match serde_cbor::to_vec(obj) {
-            Ok(m) => m,
-            Err(_) => return None,
+        let mut v: Vec<u8> = Vec::with_capacity(12);
+        // Write a dummy size that we'll then fill in later.
+        v.extend(&0u32.to_le_bytes());
+        v.extend(&msg.id.to_le_bytes());
+        v.extend(&msg.kind.to_le_bytes());
+        let mut cursor = std::io::Cursor::new(&mut v);
+        let _ = cursor.seek(SeekFrom::End(0));
+        if serde_cbor::to_writer(&mut cursor, obj).is_err() {
+            return None;
+        }
+        let size = match u32::try_from(v.len()) {
+            Ok(sz) if (4..=Self::MAX_MESSAGE_SIZE).contains(&sz) => sz - 4,
+            _ => return None,
         };
-        m.message = Some(body.into());
-        self.serialize_message_simple(&m)
+        v[0..4].copy_from_slice(&size.to_le_bytes());
+        Some(v.into())
     }
 
     pub fn serialize_body<S: Serialize>(&self, obj: &S) -> Option<Bytes> {
@@ -707,7 +730,6 @@ impl ProtocolSerializer {
     }
 
     pub fn serialize_response_simple(&self, resp: &Response) -> Option<Bytes> {
-        let mut b = BytesMut::new();
         let size = 8 + match &resp.message {
             Some(m) => m.len(),
             None => 0,
@@ -715,6 +737,7 @@ impl ProtocolSerializer {
         if size > Self::MAX_MESSAGE_SIZE as usize {
             return None;
         }
+        let mut b = BytesMut::with_capacity(size);
         let size = size as u32;
         b.extend(&size.to_le_bytes());
         b.extend(&resp.id.to_le_bytes());
@@ -727,13 +750,22 @@ impl ProtocolSerializer {
     }
 
     pub fn serialize_response_typed<S: Serialize>(&self, msg: &Response, obj: &S) -> Option<Bytes> {
-        let mut m = msg.clone();
-        let body = match serde_cbor::to_vec(obj) {
-            Ok(m) => m,
-            Err(_) => return None,
+        let mut v: Vec<u8> = Vec::with_capacity(12);
+        // Write a dummy size that we'll then fill in later.
+        v.extend(&0u32.to_le_bytes());
+        v.extend(&msg.id.to_le_bytes());
+        v.extend(&msg.code.to_le_bytes());
+        let mut cursor = std::io::Cursor::new(&mut v);
+        let _ = cursor.seek(SeekFrom::End(0));
+        if serde_cbor::to_writer(&mut cursor, obj).is_err() {
+            return None;
+        }
+        let size = match u32::try_from(v.len()) {
+            Ok(sz) if (4..=Self::MAX_MESSAGE_SIZE).contains(&sz) => sz - 4,
+            _ => return None,
         };
-        m.message = Some(body.into());
-        self.serialize_response_simple(&m)
+        v[0..4].copy_from_slice(&size.to_le_bytes());
+        Some(v.into())
     }
 
     pub fn deserialize_data(

--- a/lawn/src/server.rs
+++ b/lawn/src/server.rs
@@ -285,13 +285,13 @@ impl Server {
                     if let Ok((conn, _)) = conn {
                         let id = counter;
                         counter += 1;
-                        logger.trace(&format!("server: accepted connection, spawning handler {}", id));
+                        trace!(logger, "server: accepted connection, spawning handler {}", id);
                         let (tx, rx) = sync::mpsc::channel(1);
                         let config = self.config.clone();
                         let handle = task::spawn(async move {
                             let logger = config.logger();
                             Self::run_job(config, id, rx, conn).await;
-                            logger.trace(&format!("server: exiting handler {}", id));
+                            trace!(logger, "server: exiting handler {}", id);
                             id
                         });
                         {
@@ -314,7 +314,7 @@ impl Server {
                                 }
                             }
                             if ready {
-                                logger.trace(&format!("server: pruning idle handler {}", id));
+                                trace!(logger, "server: pruning idle handler {}", id);
                                 to_delete.insert(*id);
                             }
                         }
@@ -355,7 +355,7 @@ impl Server {
         let handler = state.handler();
         let channels = state.channels();
         let logger = state.logger();
-        logger.trace(&format!("server: {}: starting main loop", id));
+        trace!(logger, "server: {}: starting main loop", id);
         let mut interval = time::interval(Duration::from_millis(100));
         let (msg_tx, mut msg_rx) = sync::mpsc::channel(1);
         let phandler = handler.clone();
@@ -370,17 +370,17 @@ impl Server {
         loop {
             select! {
                 _ = rx.recv() => {
-                    logger.trace(&format!("server: {}: received quit signal from server", id));
+                    trace!(logger, "server: {}: received quit signal from server", id);
                     handler.close(true).await;
                     return;
                 },
                 _ = interval.tick() => {
-                    logger.trace(&format!("server: {}: periodic loop: pinging channels", id));
+                    trace!(logger, "server: {}: periodic loop: pinging channels", id);
                     // Idle loop.
                     channels.ping_channels().await;
                 }
                 res = msg_rx.recv() => {
-                    logger.trace(&format!("server: {}: message received", id));
+                    trace!(logger, "server: {}: message received", id);
                     let state = state.clone();
                     let res = match res {
                         Some(r) => r,
@@ -392,46 +392,46 @@ impl Server {
                             tokio::spawn(async move {
                                 let handler = state.handler();
                                 let logger = state.logger();
-                                logger.trace(&format!("server: {}: processing message {}", id, msg.id));
+                                trace!(logger, "server: {}: processing message {}", id, msg.id);
                                 match Self::process_message(state.clone(), id, &msg).await {
                                     Ok((ResponseType::Close, body)) => {
-                                        logger.trace(&format!("server: {}: message {}: code {:08x} (closing)", id, msg.id, 0));
+                                        trace!(logger, "server: {}: message {}: code {:08x} (closing)", id, msg.id, 0);
                                         let _ = handler.send_success(msg.id, body).await;
                                         handler.close(false).await;
                                     }
                                     Err(handler::Error::ProtocolError(protocol::Error{code, body: Some(body)})) => {
-                                        logger.trace(&format!("server: {}: message {}: code {:08x} (body)", id, msg.id, code as u32));
+                                        trace!(logger, "server: {}: message {}: code {:08x} (body)", id, msg.id, code as u32);
                                         match handler.send_error_typed(msg.id, code, &body).await {
                                             Ok(_) => (),
                                             Err(_) => handler.close(true).await,
                                         }
                                     },
                                     Err(handler::Error::ProtocolError(protocol::Error{code, body: None})) => {
-                                        logger.trace(&format!("server: {}: message {}: code {:08x}", id, msg.id, code as u32));
+                                        trace!(logger, "server: {}: message {}: code {:08x}", id, msg.id, code as u32);
                                         match handler.send_error_simple(msg.id, code).await {
                                             Ok(_) => (),
                                             Err(_) => handler.close(true).await,
                                         }
                                     },
                                     Err(e) => {
-                                        logger.trace(&format!("server: {}: message {}: error: {} (closing)", id, msg.id, e));
+                                        trace!(logger, "server: {}: message {}: error: {} (closing)", id, msg.id, e);
                                         handler.close(true).await;
                                     },
                                     Ok((ResponseType::Success, body)) => {
-                                        logger.trace(&format!("server: {}: message {}: code {:08x}", id, msg.id, 0));
+                                        trace!(logger, "server: {}: message {}: code {:08x}", id, msg.id, 0);
                                         match handler.send_success(msg.id, body).await {
                                             Ok(_) => (),
                                             Err(_) => handler.close(true).await,
                                         }
-                                        logger.trace(&format!("server: {}: message {}: code {:08x} sent", id, msg.id, 0));
+                                        trace!(logger, "server: {}: message {}: code {:08x} sent", id, msg.id, 0);
                                     },
                                     Ok((ResponseType::Partial, body)) => {
-                                        logger.trace(&format!("server: {}: message {}: code {:08x}", id, msg.id, 0));
+                                        trace!(logger, "server: {}: message {}: code {:08x}", id, msg.id, 0);
                                         match handler.send_continuation(msg.id, body).await {
                                             Ok(_) => (),
                                             Err(_) => handler.close(true).await,
                                         }
-                                        logger.trace(&format!("server: {}: message {}: code {:08x} sent", id, msg.id, 0));
+                                        trace!(logger, "server: {}: message {}: code {:08x} sent", id, msg.id, 0);
                                     },
                                 }
                             });
@@ -446,7 +446,7 @@ impl Server {
                 },
                 chanid = chandeathrx.recv() => {
                     if let Some(chanid) = chanid {
-                        logger.trace(&format!("server: {}: received channel death for channel {}", id, chanid));
+                        trace!(logger, "server: {}: received channel death for channel {}", id, chanid);
                         let state = state.clone();
                         task::spawn(async move {
                             Self::notify_channel_death(state, chanid).await;
@@ -540,7 +540,7 @@ impl Server {
         let logger = state.logger();
         match MessageKind::from_u32(message.kind) {
             Some(MessageKind::Capability) => {
-                logger.trace(&format!("server: {}: capability message", id));
+                trace!(logger, "server: {}: capability message", id);
                 let c = protocol::CapabilityResponse {
                     version: vec![0x00000000],
                     capabilities: state
@@ -554,7 +554,7 @@ impl Server {
                 Ok((ResponseType::Success, serializer.serialize_body(&c)))
             }
             Some(MessageKind::Version) => {
-                logger.trace(&format!("server: {}: version message", id));
+                trace!(logger, "server: {}: version message", id);
                 handler.flush_requests().await;
                 let m = valid_message!(handler, protocol::VersionRequest, message);
                 let supported = state.config().capabilities();
@@ -580,15 +580,15 @@ impl Server {
                 }
             }
             Some(MessageKind::CloseAlert) => {
-                logger.trace(&format!("server: {}: close alert", id));
+                trace!(logger, "server: {}: close alert", id);
                 Ok((ResponseType::Close, None))
             }
             Some(MessageKind::Ping) => {
-                logger.trace(&format!("server: {}: ping", id));
+                trace!(logger, "server: {}: ping", id);
                 Ok((ResponseType::Success, None))
             }
             Some(MessageKind::Authenticate) => {
-                logger.trace(&format!("server: {}: authenticate", id));
+                trace!(logger, "server: {}: authenticate", id);
                 handler.flush_requests().await;
                 let m = valid_message!(handler, protocol::AuthenticateRequest, message);
                 if m.last_id.is_some() || m.message.is_some() || m.method != b"EXTERNAL" as &[u8] {
@@ -665,7 +665,7 @@ impl Server {
                 Ok((ResponseType::Success, None))
             }
             Some(MessageKind::CreateChannel) => {
-                logger.trace(&format!("server: {}: create channel", id));
+                trace!(logger, "server: {}: create channel", id);
                 assert_authenticated!(handler, message);
                 let m = valid_message!(handler, protocol::CreateChannelRequest, message);
                 logger.trace(&format!(
@@ -714,13 +714,13 @@ impl Server {
                         Ok((ResponseType::Success, serializer.serialize_body(&r)))
                     }
                     Err(_) => {
-                        logger.trace(&format!("server: {}: create channel: failed", id));
+                        trace!(logger, "server: {}: create channel: failed", id);
                         Err(ResponseCode::InvalidParameters.into())
                     }
                 }
             }
             Some(MessageKind::ReadChannel) => {
-                logger.trace(&format!("server: {}: read channel", id));
+                trace!(logger, "server: {}: read channel", id);
                 assert_authenticated!(handler, message);
                 let m = valid_message!(handler, protocol::ReadChannelRequest, message);
                 let ch = match channels.get(m.id) {
@@ -735,7 +735,7 @@ impl Server {
                 Ok((ResponseType::Success, serializer.serialize_body(&resp)))
             }
             Some(MessageKind::WriteChannel) => {
-                logger.trace(&format!("server: {}: write channel", id));
+                trace!(logger, "server: {}: write channel", id);
                 assert_authenticated!(handler, message);
                 let m = valid_message!(handler, protocol::WriteChannelRequest, message);
                 let ch = match channels.get(m.id) {
@@ -751,7 +751,7 @@ impl Server {
                 Ok((ResponseType::Success, serializer.serialize_body(&resp)))
             }
             Some(MessageKind::DeleteChannel) => {
-                logger.trace(&format!("server: {}: delete channel", id));
+                trace!(logger, "server: {}: delete channel", id);
                 assert_authenticated!(handler, message);
                 let m = valid_message!(handler, protocol::DeleteChannelRequest, message);
                 match channels.remove(m.id) {
@@ -761,7 +761,7 @@ impl Server {
                 Ok((ResponseType::Success, None))
             }
             Some(MessageKind::DetachChannelSelector) => {
-                logger.trace(&format!("server: {}: detach channel selector", id));
+                trace!(logger, "server: {}: detach channel selector", id);
                 assert_authenticated!(handler, message);
                 let m = valid_message!(handler, protocol::DetachChannelSelectorRequest, message);
                 let ch = match channels.get(m.id) {
@@ -774,7 +774,7 @@ impl Server {
                 }
             }
             Some(MessageKind::PollChannel) => {
-                logger.trace(&format!("server: {}: poll channel", id));
+                trace!(logger, "server: {}: poll channel", id);
                 assert_authenticated!(handler, message);
                 let m = valid_message!(handler, protocol::PollChannelRequest, message);
                 let ch = match channels.get(m.id) {
@@ -805,7 +805,7 @@ impl Server {
                 Ok((ResponseType::Success, serializer.serialize_body(&resp)))
             }
             Some(MessageKind::PingChannel) => {
-                logger.trace(&format!("server: {}: ping channel", id));
+                trace!(logger, "server: {}: ping channel", id);
                 assert_authenticated!(handler, message);
                 let m = valid_message!(handler, protocol::PingChannelRequest, message);
                 let ch = match channels.get(m.id) {


### PR DESCRIPTION
This series includes a variety of microoptimzations to improve the round-trip performance of messages, especially when parsing.  There is a patch to avoid needless reallocations when parsing messages, a patch to box messages to avoid copying them when passing them through a channel, and a patch that enables the use of the `trace!` macro to avoid formatting strings needlessly when we're not tracing.