### PR TITLE
Add some additional tests

### DIFF
--- a/lawn/src/config.rs
+++ b/lawn/src/config.rs
@@ -1212,5 +1212,7 @@ mod tests {
             level: LogLevel::Debug,
         };
         trace!(logger, "this should never be invoked");
+        let body: Option<u32> = None;
+        trace!(logger, "nor should this: {:?}", body.unwrap());
     }
 }


### PR DESCRIPTION
Add some additional tests, including that our trace macros don't call any code when they're disabled and a variety of serialization tests so we can have confidence that our data implements the protocol we've defined.