### PR TITLE
Add timeouts for `lawn proxy`

### DIFF
--- a/doc/examples/configuration.yaml
+++ b/doc/examples/configuration.yaml
@@ -45,6 +45,26 @@ v0:
     # command, we attempt to connect to all found sockets and remove those where
     # the connection fails.
     autoprune: true
+  # Controls for `lawn proxy`.
+  proxy:
+    # Controls for SSH agent proxying with `lawn proxy` (currently the only type).
+    ssh:
+      # Timeout controls.
+      timeout:
+        # The SSH agent protocol requires the client to speak first.  In order
+        # to ensure that asynchronous messages from the server are received, the
+        # client sends a no-op message every so often.  Setting a lower value
+        # produces more responsive behaviour at the cost of additional network
+        # traffic and reduced robustness to bad connections.  This option
+        # controls the frequency in ms of this poll.
+        poll_ms: 50
+        # Because of the above limitation, we want to wait a short amount of
+        # time for the server to respond to a client message to avoid waiting
+        # for the next poll delay.  Setting a lower value allows more client
+        # requests at the cost of a potentially longer response time to those
+        # requests.  This timeout is the number of ms to wait for a response
+        # from the server before returning an empty response over the protocol.
+        server_read_ms: 15
   # The clipboard controls
   clipboard:
     # A boolean expression determining whether to allow operations on the clipboard.

--- a/lawn/src/ssh_proxy.rs
+++ b/lawn/src/ssh_proxy.rs
@@ -236,7 +236,9 @@ impl Proxy {
                         ours_write.write_all(&ours).await?;
                         trace!(logger, "proxy: relayed message");
                         let mut buf = vec![0u8; 65536];
-                        let _ = tokio::time::timeout(self.server_read_timeout, ours_read.readable()).await;
+                        let _ =
+                            tokio::time::timeout(self.server_read_timeout, ours_read.readable())
+                                .await;
                         match ours_read.try_read(&mut buf) {
                             // We have a message from the server to send.
                             Ok(n) => {

--- a/lawn/src/ssh_proxy.rs
+++ b/lawn/src/ssh_proxy.rs
@@ -97,6 +97,7 @@ pub struct Proxy {
     ours_write: Arc<Mutex<OwnedWriteHalf>>,
     multiplex: Arc<Mutex<UnixStream>>,
     config: Arc<Config>,
+    server_read_timeout: Duration,
 }
 
 impl Proxy {
@@ -107,6 +108,7 @@ impl Proxy {
         multiplex: UnixStream,
     ) -> Proxy {
         let (rd, wr) = ours.into_split();
+        let server_read_timeout = config.proxy_server_read_timeout();
         Proxy {
             config,
             ssh: match ssh {
@@ -116,6 +118,7 @@ impl Proxy {
             ours_read: Arc::new(Mutex::new(rd)),
             ours_write: Arc::new(Mutex::new(wr)),
             multiplex: Arc::new(Mutex::new(multiplex)),
+            server_read_timeout,
         }
     }
 
@@ -149,7 +152,7 @@ impl Proxy {
     /// messages into the SSH protocol for use on the other side.
     pub async fn run_client(&self) -> Result<(), Error> {
         use tokio::io::AsyncReadExt;
-        let mut interval = tokio::time::interval(Duration::from_millis(100));
+        let mut interval = tokio::time::interval(self.config.proxy_poll_timeout());
         let mut ours_read = self.ours_read.lock().await;
         let logger = self.config.logger();
         let mut buf = vec![0u8; 65536];
@@ -233,6 +236,7 @@ impl Proxy {
                         ours_write.write_all(&ours).await?;
                         trace!(logger, "proxy: relayed message");
                         let mut buf = vec![0u8; 65536];
+                        let _ = tokio::time::timeout(self.server_read_timeout, ours_read.readable()).await;
                         match ours_read.try_read(&mut buf) {
                             // We have a message from the server to send.
                             Ok(n) => {


### PR DESCRIPTION
The SSH agent protocol operates such that the client always speaks first.  Normally, this is true of the Lawn protocol as well, but we can receive exit notifications from the server when running a command, so we also need a way for the server to send asynchronous responses.

The solution, unfortunately, is to poll.  We have traditionally had a 100 ms delay after which we send an empty poll packet, such that we can receive asynchronous responses no later than this.

However, as this stands, we have a slight performance problem.  If the server response is not completely ready when we read it, we send back an empty response and we need to wait for the next poll.  Instead, let's wait a few milliseconds to see if a response is ready, and if so, send it right away.

This actually dramatically improves performance: a `lawn query test-connection` with `lawn proxy` on the same machine goes from 0.410 s to 0.011 s, which is a substantial improvement.  To see if we can improve performance a little more, adjust the default timeout for polling to 50 ms.

Because sometimes these values won't work in some case or another, let's also make them configurable so that users can adjust the configuration which suits them best.