### PR TITLE
Add support for Miri

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,18 @@ jobs:
       with:
         ruby-version: 3.1
     - run: make ci-nightly
+  build-miri:
+    name: Linux (Miri)
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Install Miri
+      run: |
+        rustup toolchain install nightly --component miri
+        rustup override set nightly
+        cargo miri setup
+    - name: Test with Miri
+      run: cargo miri test
   build-freebsd:
     name: FreeBSD
     runs-on: macos-12

--- a/lawn-9p/src/backend/libc.rs
+++ b/lawn-9p/src/backend/libc.rs
@@ -1035,6 +1035,7 @@ impl Backend for LibcBackend {
     }
 }
 
+#[cfg(not(miri))]
 #[cfg(test)]
 mod tests {
     use super::LibcBackend;

--- a/lawn-fs/src/backend/libc.rs
+++ b/lawn-fs/src/backend/libc.rs
@@ -1621,6 +1621,7 @@ impl Backend for LibcBackend {
     }
 }
 
+#[cfg(not(miri))]
 #[cfg(test)]
 mod tests {
     use super::{LibcBackend, MaybeIDInfo};

--- a/lawn-sftp/src/backend.rs
+++ b/lawn-sftp/src/backend.rs
@@ -839,6 +839,7 @@ impl Backend {
     }
 }
 
+#[cfg(not(miri))]
 #[cfg(test)]
 mod tests {
     use super::{

--- a/lawn/src/config.rs
+++ b/lawn/src/config.rs
@@ -1174,6 +1174,7 @@ mod tests {
         cfg
     }
 
+    #[cfg(not(miri))]
     #[test]
     fn default_is_root() {
         let mut env = BTreeMap::new();
@@ -1193,6 +1194,7 @@ mod tests {
         assert_eq!(cfg.is_root().unwrap(), true);
     }
 
+    #[cfg(not(miri))]
     #[test]
     fn is_root_with_values() {
         let cfg = config_with_values(BTreeMap::new(), |c| {

--- a/lawn/src/main.rs
+++ b/lawn/src/main.rs
@@ -33,6 +33,7 @@ mod server;
 mod ssh_proxy;
 mod task;
 mod template;
+#[cfg(not(miri))]
 #[cfg(test)]
 mod tests;
 mod unix;


### PR DESCRIPTION
Miri is an experimental interpreter for Rust that can check for certain kinds of undefined behaviour.  Let's get the testsuite working with it as much as possible.

Note that Miri currently does not support Tokio, since it doesn't support `epoll_wait`, and it won't work with our code that calls into Rustix (that is, anything involving the `lawn-fs` code).  We disable these tests there to make the testsuite compile and run correctly.