### PR TITLE
Add basic support for credential stores

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -235,6 +235,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "format-bytes"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48942366ef93975da38e175ac9e10068c6fc08ca9e85930d4f098f4d5b14c2fd"
+dependencies = [
+ "format-bytes-macros",
+]
+
+[[package]]
+name = "format-bytes-macros"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "203aadebefcc73d12038296c228eabf830f99cba991b0032adf20e9fa6ce7e4f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -332,6 +352,7 @@ dependencies = [
  "bytes",
  "clap",
  "daemonize",
+ "format-bytes",
  "hex",
  "lawn-9p",
  "lawn-constants",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-trait"
+version = "0.1.66"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b84f9ebcc6c1f5b8cb160f6990096a5c127f423fcb6e1ccc46c370cbdfb75dfc"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -39,6 +50,24 @@ name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "blake2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+dependencies = [
+ "digest",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
 
 [[package]]
 name = "boxfnonce"
@@ -124,6 +153,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
 name = "daemonize"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -131,6 +170,17 @@ checksum = "70c24513e34f53b640819f0ac9f705b673fcf4006d7aab8778bee72ebfc89815"
 dependencies = [
  "boxfnonce",
  "libc",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -176,6 +226,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "form_urlencoded"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "half"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -209,6 +278,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "idna"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+]
+
+[[package]]
 name = "indexmap"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -239,9 +318,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "itoa"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
+
+[[package]]
 name = "lawn"
 version = "0.3.0"
 dependencies = [
+ "async-trait",
+ "blake2",
  "bytes",
  "clap",
  "daemonize",
@@ -256,11 +343,15 @@ dependencies = [
  "num-traits",
  "serde",
  "serde_cbor",
+ "serde_json",
  "serde_yaml",
  "signal-hook-tokio",
+ "subtle",
  "tempfile",
+ "thiserror",
  "tokio",
  "tokio-pipe",
+ "url",
 ]
 
 [[package]]
@@ -489,6 +580,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "percent-encoding"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -496,18 +593,18 @@ checksum = "e280fbe77cc62c91527259e9442153f4688736748d24660126286329742b4c6c"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.36"
+version = "1.0.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7342d5883fbccae1cc37a2353b09c87c9b0f3afd73f5fb9bba687a1f733b029"
+checksum = "92de25114670a878b1261c79c9f8f729fb97e95bac93f6312f583c60dd6a1dfe"
 dependencies = [
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.15"
+version = "1.0.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "864d3e96a899863136fc6e99f3d7cae289dafe43bf2c5ac19b70df7210c0a145"
+checksum = "5907a1b7c277254a8b15170f6e7c97cfa60ee7872a3217663bb81151e48184bb"
 dependencies = [
  "proc-macro2",
 ]
@@ -564,9 +661,9 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "serde"
-version = "1.0.136"
+version = "1.0.156"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce31e24b01e1e524df96f1c2fdd054405f8d7376249a5110886fb4b658484789"
+checksum = "314b5b092c0ade17c00142951e50ced110ec27cea304b1037c6969246c2469a4"
 dependencies = [
  "serde_derive",
 ]
@@ -583,13 +680,24 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.136"
+version = "1.0.156"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08597e7152fcd306f41838ed3e37be9eaeed2b61c42e2117266a554fab4662f9"
+checksum = "d7e29c4601e36bcec74a223228dce795f4cd3616341a4af93520ca1a837c087d"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.99"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46266871c240a00b8f503b877622fe33430b3c7d963bdc0f2adc511e54a1eae3"
+dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]
@@ -647,14 +755,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
-name = "syn"
-version = "1.0.86"
+name = "subtle"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a65b3f4ffa0092e9887669db0eae07941f023991ab58ea44da8fe8e2d511c6b"
+checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
  "proc-macro2",
  "quote",
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -679,6 +793,41 @@ checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 dependencies = [
  "unicode-width",
 ]
+
+[[package]]
+name = "thiserror"
+version = "1.0.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5ab016db510546d856297882807df8da66a16fb8c4101cb8b30054b0d5b2d9c"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5420d42e90af0c38c3290abcca25b9b3bdf379fc9f55c528f53a269d9c9a267e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tinyvec"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
@@ -720,22 +869,60 @@ dependencies = [
 ]
 
 [[package]]
+name = "typenum"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
+
+[[package]]
+name = "unicode-bidi"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460"
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "301abaae475aa91687eb82514b328ab47a211a533026cb25fc3e519b86adfc3c"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
 name = "unicode-width"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
 
 [[package]]
-name = "unicode-xid"
-version = "0.2.2"
+name = "url"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
+checksum = "31e6302e3bb753d46e83516cae55ae196fc0c309407cf11ab35cc51a4c2a4633"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+]
 
 [[package]]
 name = "vec_map"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
+
+[[package]]
+name = "version_check"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "winapi"

--- a/LICENSE
+++ b/LICENSE
@@ -4,6 +4,11 @@ Files: *
 Copyright: 2022 brian m. carlson
 License: Expat
 
+Files: lawn/src/serializer/script.rs
+Copyright: 2023 brian m. carlson
+           Contributors to the Rust Project
+License: Expat
+
 License: Expat
  Permission is hereby granted, free of charge, to any
  person obtaining a copy of this software and associated

--- a/Makefile
+++ b/Makefile
@@ -158,7 +158,7 @@ test/Dockerfile.%: test/Dockerfile.%.erb $(INCLUDES)
 
 clippy:
 	rm -rf target/debug target/release
-	cargo clippy $(FEATURE_ARG) -- -A clippy::unknown-clippy-lints -A clippy::needless_borrow -A clippy::bad_bit_mask -D warnings
+	cargo clippy $(FEATURE_ARG) -- -A clippy::unknown-clippy-lints -A clippy::manual-strip -A clippy::needless_borrow -A clippy::bad_bit_mask -D warnings
 
 fmt:
 	if rustfmt --help | grep -qse --check; \

--- a/doc/protocol.adoc
+++ b/doc/protocol.adoc
@@ -8,6 +8,41 @@ https://datatracker.ietf.org/doc/html/rfc2119[RFC 2119].
 The CBOR structures in this document are written in terms of Rust structures without the `pub`, `struct`, or type name and the allowed use of kebab-case.
 Byte strings are referred to as `Bytes`, maps as `Map`, and sequences as `Vec` or as a tuple.
 A type of `Value` represents a value of any CBOR type whose interpretation will be further explained.
+A type of `Option` represents a value of the given type, which is serialized as normal, or a CBOR null.
+If it is not present in the serialization, it is assumed to be null.
+
+An enumeration is serialized as a hash, with the enumeration variant being the key and the value as the value.
+If there is no value, then the value is null.
+Thus, the structure with this enumeration:
+
+----
+{
+  foo: {
+    path(String),
+    id(u32)
+  }
+}
+----
+
+is serialized as one of the following two structures:
+
+----
+{
+  foo: {
+    path: String
+  }
+}
+----
+
+or
+
+----
+{
+  foo: {
+    id: u32
+  }
+}
+----
 
 == Main Protocol (version 0)
 
@@ -162,6 +197,22 @@ An implementation supporting the `extension=allocate` capability must support th
 * DeleteExtensionRange
 * ListExtensionRange
 
+An implementation supporting any two-part capability with the first part of `store` must support the following requests:
+
+* OpenStore
+* CloseStore
+* ListStoreElements
+* AcquireStoreElement
+* CloseStoreElement
+* AuthenticateStoreElement
+* CreateStoreElement
+* DeleteStoreElement
+* UpdateStoreElement
+* ReadStoreElement
+* SearchStoreElements
+
+Such an implementation must also support the Unlisted response.
+
 === Major Concepts
 
 ==== Channels
@@ -171,6 +222,23 @@ Each independent stream of bytes is referred to by a selector, and can be read a
 The selector can be thought of in many ways like a Unix file descriptor.
 
 Channels can be used for invoking commands, where the selectors 0, 1, and 2 refer to the streams normally associated with those file descriptors, and they can also be used for streaming various protocols, such as the 9P2000 protocol.
+
+==== Stores
+
+A store provides some set of structured, possibly nested data, upon which the typical CRUD (create, read, update, delete) operations can be performed.
+A store may possibly be encrypted or require authentication at various levels.
+
+All stores start with a root entry, specified as `/`, which is a directory element.
+Directory elements always end with a slash and may contain zero or more directory or file elements.
+File elements contain some sort of structured data, which is usually specified as part of the type of store.
+Components are not presently allowed to contain the `%` sign, which is reserved for future extension.
+
+By default, store items can be accessed directly using a path, which consists of slash-separated byte strings, much like a Unix path, but if one or more of the directory elements is encrypted or requires authentication, then that element must be opened with a handle.
+
+Stores can be used for any sort of structured data, including credentials.
+
+Objects in stores can be specified either with an absolute path (called a _store selector path_) or with an ID (called a _store selector ID_).
+The latter is a 32-bit integer returned by some store operations and is not the same as the ID which is returned in the path.
 
 === Requests
 
@@ -207,15 +275,20 @@ The following capabilities are known:
 |===
 | Key | Value | Meaning
 
-| `auth`      | `EXTERNAL`           | external authentication
-| `auth`      | any uppercase string | Any standardized SASL authentication mechanism
-| `auth`      | any lowercase string | Reserved for future Lawn-defined authentication mechanisms
-| `auth`      | any extension string | Reserved for custom extensions
+| `auth`      | `EXTERNAL`             | external authentication
+| `auth`      | `PLAIN`                | SASL PLAIN authentication
+| `auth`      | `keyboard-interactive` | SASL PLAIN authentication
+| `auth`      | any uppercase string   | Any standardized SASL authentication mechanism
+| `auth`      | any lowercase string   | Reserved for future Lawn-defined authentication mechanisms
+| `auth`      | any extension string   | Reserved for custom extensions
 
 | `channel`   | `9p`                 | 9P channels (including all variants of the protocol)
 | `channel`   | `clipboard`          | clipboard channels
 | `channel`   | `command`            | command channels
 | `channel`   | any extension string | Reserved for custom extensions
+
+| `store`     | `credential`         | credential stores
+| `store`     | any extension string | Reserved for custom extensions
 
 | `extension` | `allocate`           | dynamic message code extensions
 
@@ -749,6 +822,496 @@ If an enabled extension is given different values for client and server (say, be
 
 This message requires authentication and is paginated.
 
+==== OpenStore
+
+The open store request (`0x00030000`) requests that a store be opened.
+
+A store is a structured set of data which may be nested.
+An object is referred to by a path, which always starts with a slash (that is, it is always absolute) and is slash-separated into components.
+At the moment, percent signs are not permitted in path components to allow for future escaping.
+
+An implementation MUST NOT send a message requesting a store type that was not advertised as a capability, and if such a message is received, a ParametersNotSupported response should be sent.
+
+The following store types are known:
+
+|===
+| Store Type | Meaning
+
+|  `credential`         | store for credentials
+|  any extension string | Reserved for custom extensions
+
+|===
+
+A request looks like this:
+
+----
+{
+  kind: Bytes,
+  path: Option<Bytes>,
+  meta: Option<BTreeMap<Bytes, Value>>,
+}
+----
+
+`meta` may contain keys with extension strings if necessary.
+
+On success, a response looks like this:
+
+----
+{
+  id: u32,
+}
+----
+
+The ID returned is referred to as a store ID and is used in future requests to identify this store.
+
+===== Credential Stores
+
+Credential stores are designed to provide access to a variety of credentials using one or more helpers.
+This allows users to access credentials in a variety of ways.
+
+At the moment, paths are structured like so:
+
+* `/BACKEND/VAULT/ENTRY`
+* `/BACKEND/VAULT/VAULT-DIRECTORY/ENTRY`
+* `/BACKEND/VAULT/VAULT-DIRECTORY/VAULT-DIRECTORY/ENTRY`
+
+and so on.
+The number of vault directories is effectively unlimited and whether they are allowed and how deep depends on the credential helper.
+
+Some credential stores are considered _listable_ and thus can have their contents listed, and others are not.
+This limitation exists to support calling backends such as Git credential helpers, which can merely fill, save, or delete a credential, but cannot iterate over the contents of credentials.
+Some credential stores may be listable at some levels (e.g., the vaults available) but not at others (e.g., the individual credentials).
+The Unlistable response is used to indicate that credentials cannot be listed at a given level.
+
+Some credential stores do not provide an enumerated list of vaults.
+In such a case, the vault component will be called `-`, which is the default value.
+
+The `kind` value is always `credential` or `directory`.
+The `path` component in an OpenStore request is not used and should be null.
+The `meta` values are not used unless an extension string is specified as a key and should otherwise be null.
+
+A credential body looks like this:
+
+----
+{
+  username: Option<Bytes>,
+  secret: Option<Bytes>,
+  authtype: Option<String>,
+  type: String,
+  title: Option<String>,
+  description: Option<String>,
+  location: Vec<CredentialStoreLocation>,
+  service: Option<String>,
+  extra: Map<String, Value>,
+  id: Bytes,
+}
+----
+
+`username` represents a username for this credential.
+`secret` represents the password, key, or other secret.
+It is required when creating or updating a credential.
+`authtype` specifies an authentication type for this credential, which may be protocol specific.
+For example, for an HTTP request, `basic`, `digest`, and `bearer` may be values.
+If not specified, the secret is assumed to be generic.
+`type` is specified below.
+`location` indicates a set of locations linked to this secret.
+For example, it might be the website to which this credential belongs, or the API service or IMAP server.
+`service` is the name of the service or software to which this credential belongs.
+If the software is a Unix program, it may precede `@unix.ns.crustytoothpaste.net` to allow arbitrary values.
+`extra` allows extra values which may be relevant.
+Extension strings are allowed as keys.
+`id` is the unique ID for this entry.
+
+A `CredentialStoreLocation` looks like this:
+
+----
+{
+  protocol: Option<String>,
+  host: Option<String>,
+  port: Option<u16>,
+  path: Option<String>,
+}
+----
+
+All the fields in this structure are serialized as if they appeared in a URI as defined by https://datatracker.ietf.org/doc/html/rfc3986[RFC 3986].
+
+A credential may have a variety of values for the `type` field:
+
+|===
+| Name | Meaning
+
+| `api`            | the credential is used for automated access to a system (e.g., as a username/password or token)
+| `ssh`            | the credential is an SSH key in a format known to OpenSSH
+| `pkcs12`         | the credential is a PKCS#12 file in binary format using DER
+| `login`          | the credential is used for human-related access to a system (e.g., as a username/password or token)
+| `totp`           | the credential is used as a TOTP secret
+| extension string | specified by the owner
+|===
+
+A credential or request may have a variety of values for the `extra` entries:
+
+|===
+| Name | Type | Meaning
+
+| `link`                                | Vec<Bytes> | related secrets (e.g., the TOTP secret related to a login and vice versa)
+| `wwwauth@git.ns.crustytoothpaste.net` | Vec<Bytes> | values for the Git credential helper `wwwauth[]` field
+| `*@user.ns.crustytoothpaste.net`      | Any        | metadata specified by the end user
+| extension string                      | Any        | specified by the owner
+|===
+
+A search credential body looks like this:
+
+----
+{
+  username: SearchStoreElementType,
+  secret: SearchStoreElementType,
+  authtype: SearchStoreElementType,
+  kind: SearchStoreElementType,
+  protocol: SearchStoreElementType,
+  host: SearchStoreElementType,
+  title: SearchStoreElementType,
+  description: SearchStoreElementType,
+  path: SearchStoreElementType,
+  service: SearchStoreElementType,
+  extra: Map<String, SearchStoreElementType>,
+  id: SearchStoreElementType,
+}
+----
+
+The fields have exactly the same meaning as in the credential body.
+
+A `SearchStoreElementType` is an enum that looks like this:
+
+----
+{
+  literal(Value),
+  set(Vec<SearchStoreElementType>)
+  sequence(Vec<SearchStoreElementType>)
+  any(null),
+  none(null),
+}
+----
+
+==== CloseStore
+
+The close store request (`0x00030001`) requests that a store be closed and its associated resources be freed.
+
+A request looks like this:
+
+----
+{
+  id: u32,
+}
+----
+
+`id` is a store ID returned by the OpenStore request.
+`selector` is either a path or an store selector ID.
+
+On success, an empty response is returned.
+
+==== ListStoreElements
+
+The list store elements request (`0x00030002`) requests that a store be closed and its associated resources be freed.
+
+A request looks like this:
+
+----
+{
+  id: u32,
+  selector: {
+    path(Bytes),
+    id(u32)
+  }
+}
+----
+
+`id` is a store ID returned by the OpenStore request.
+`selector` is either a path or an store selector ID.
+
+On success, a response, whether initial or continuation, looks like this:
+
+----
+{
+  elements: Vec<StoreElement>,
+}
+----
+
+The `StoreElement` structure looks like this:
+
+----
+{
+  path: Bytes,
+  id: u32,
+  kind: String,
+  needs_authentication: Option<bool>,
+  authentication_methods: Option<Vec<Bytes>>,
+  meta: Option<Map<Bytes, Value>>,
+}
+----
+
+`path` is a path to the item.
+`id` is a store selector ID for this item.
+`kind` refers to the kind of this item.
+The kind will be either `directory` for a directory or the appropriate type for the store in question.
+`needs_authentication` is true if authentication is required, false if it is not, and null if it is not known.
+`authentication_methods` is a list of valid authentication methods.
+`meta` is a set of metadata about this item, which may include extension strings as keys.
+
+This message requires authentication and is paginated.
+
+==== AcquireStoreElement
+
+The acquire store element request (`0x00030003`) requests that an ID be assigned to a path.
+
+A request looks like this:
+
+----
+{
+  id: u32,
+  selector: Bytes
+}
+----
+
+`id` is a store ID returned by the OpenStore request.
+`selector` is a path.
+
+On success, a response looks like this:
+
+----
+{
+  selector: u32,
+}
+----
+
+`selector` is a store selector ID.
+
+This message requires authentication.
+
+==== CloseStoreElement
+
+The close store element request (`0x00030004`) requests that an ID be freed.
+
+A request looks like this:
+
+----
+{
+  id: u32,
+  selector: u32,
+}
+----
+
+`id` is a store ID returned by the OpenStore request.
+`selector` is a store selector ID.
+
+On success, an empty response is returned.
+
+This message requires authentication.
+
+==== AuthenticateStoreElement
+
+The authenticate store element request (`0x00030005`) requests that authentication be performed for a store element.
+Most commonly, this is used against the backend or vault of a credential store to allow it to be unlocked.
+
+A request looks like this:
+
+----
+{
+  id: u32,
+  selector: u32,
+  method: Bytes,
+  message: Option<Bytes>,
+}
+----
+
+`id` is a store ID returned by the OpenStore request.
+`selector` is a store selector ID.
+The `method` and `message` fields are identical in meaning to those specified in the Authenticate request.
+
+On success, a response looks like this:
+
+----
+{
+  method: Bytes,
+  message: Option<Bytes>
+}
+----
+
+Continuation requests and responses are identical to the original message.
+
+Typically, a response to this request will be Success, AuthenticationFailed, Invalid, or Continuation.
+
+This message requires authentication.
+
+==== CreateStoreElement
+
+The create store element request (`0x00030006`) requests that a store element be created.
+
+A request looks like this:
+
+----
+{
+  id: u32,
+  selector: {
+    path(Bytes),
+    id(u32)
+  }
+  kind: String,
+  needs-authentication: Option<bool>,
+  authentication-methods: Option<Vec<Bytes>>,
+  meta: Option<Map<Bytes, Value>>,
+  body: type-specific
+}
+----
+
+`id` is a store ID returned by the OpenStore request.
+`selector` is a store selector.
+`kind` is the kind for this item.
+The kind will be either `directory` for a directory or the appropriate type for the store in question.
+`needs-authentication` is true if the item is expected to need authentication, false if it is not, or null to choose the default, which is usually the same as the vault or backend used.
+`authentication-methods` controls the authentication methods used and should be set to null to inherit the options.
+`meta` is an optional set of metadata attributes, which should be null unless needed.
+Extension strings may be used as keys.
+`body` is the type-specific body, which for credentials is a credential body.
+
+On success, the response is empty.
+
+This message requires authentication.
+
+==== DeleteStoreElement
+
+The delete store element request (`0x00030007`) requests that a store element be created.
+
+A request looks like this:
+
+----
+{
+  id: u32,
+  selector: {
+    path(Bytes),
+    id(u32)
+  }
+}
+----
+
+On success, the response is empty.
+
+This message requires authentication.
+
+==== UpdateStoreElement
+
+The update store element request (`0x00030008`) requests that an existing store element be updated.
+
+A request looks like this:
+
+----
+{
+  id: u32,
+  selector: {
+    path(Bytes),
+    id(u32)
+  }
+  kind: String,
+  needs-authentication: Option<bool>,
+  authentication-methods: Option<Vec<Bytes>>,
+  meta: Option<Map<Bytes, Value>>,
+  body: type-specific
+}
+----
+
+The fields have exactly the same meaning as in the CreateStoreElement request.
+
+On success, the response is empty.
+
+This message requires authentication.
+
+==== ReadStoreElement
+
+The read store element request (`0x00030009`) requests that the data for a store element be returned.
+
+A request looks like this:
+
+----
+{
+  id: u32,
+  selector: {
+    path(Bytes),
+    id(u32)
+  }
+}
+----
+
+On success, the response looks like this:
+
+----
+{
+  kind: String,
+  needs-authentication: Option<bool>,
+  authentication-method: Option<Vec<Bytes>>,
+  meta: Option<Map<Bytes, Value>>,
+  body: type-specific,
+}
+----
+
+The meaning of the values are the same as for the CreateStoreElement request.
+
+This message requires authentication.
+
+==== SearchStoreElements
+
+The search store elements request (`0x0003000c`) requests a search for store elements matching certain criteria.
+
+A request looks like this:
+
+----
+{
+  id: u32,
+  selector: {
+    path(Bytes),
+    id(u32)
+  },
+  recurse: {
+    boolean(bool)
+  },
+  kind: Option<String>,
+  body: Option<type-specific>,
+}
+----
+
+The `recurse` field determines whether this search is recursive.
+It is dependent on the backend whether recursive or non-recursive search is implemented.
+
+The `body` field should be null for searching directories and should be non-null with a type-specific search body for non-directories.
+
+On success, the response looks like this:
+
+----
+{
+  elements: Vec<StoreElement>,
+}
+----
+
+The `StoreElement` field looks like this:
+
+----
+{
+  path: Bytes,
+  id: Option<u32>,
+  kind: String,
+  needs-authentication: Option<bool>,
+  authentication-methods: Option<Vec<Bytes>>,
+  meta: Option<Map<Bytes, Value>>,
+  body: Option<type-specific>,
+}
+----
+
+`path` is the absolute path.
+`id` is a store selector ID, if available.
+The body is a normal type-specific body or null if there is no such body.
+
+The meaning of the values are otherwise the same as for the CreateStoreElement request.
+
+This request is paginated and requires authentication.
+
 === Responses
 
 Response codes are grouped by category by their first sixteen bits.
@@ -995,6 +1558,11 @@ This could be due to any sort of resource exhaustion: memory, disk, or any serve
 The conflict response (`0x0001000d`) indicates that the requested operation would conflict with some operation that either has already completed or is in progress.
 
 The semantics of this value are those of an HTTP 409 response.
+
+==== Unlistable
+
+The unlistable response (`0x0001000e`) indicates that the contents of the object cannot be listed or specified by name.
+This is used with stores, and specifically credential stores, when items may be searched but not listed.
 
 ==== NotEnabled
 

--- a/lawn-constants/src/error.rs
+++ b/lawn-constants/src/error.rs
@@ -347,10 +347,22 @@ impl From<Error> for io::Error {
 }
 
 impl From<io::Error> for Error {
+    fn from(err: io::Error) -> Error {
+        Error::from(&err)
+    }
+}
+
+impl<'a> From<&'a mut io::Error> for Error {
+    fn from(err: &'a mut io::Error) -> Error {
+        Error::from(&*err)
+    }
+}
+
+impl<'a> From<&'a io::Error> for Error {
     // Some OSes, like Linux, are missing separate values for some errors and we don't want a
     // warning here.
     #[allow(unreachable_patterns)]
-    fn from(err: io::Error) -> Error {
+    fn from(err: &'a io::Error) -> Error {
         match err.raw_os_error() {
             Some(libc::EPERM) => Self::EPERM,
             Some(libc::ENOENT) => Self::ENOENT,

--- a/lawn-protocol/src/protocol/mod.rs
+++ b/lawn-protocol/src/protocol/mod.rs
@@ -99,6 +99,11 @@ pub enum ResponseCode {
     ///
     /// The semantics for this message are equivalent to an HTTP 409 response.
     Conflict = 0x0001000d,
+    /// The contents of the object cannot be listed or specified by name.
+    ///
+    /// For example, when using a Git-protocol credential helper, it is not possible to enumerate
+    /// all credentials or pick a credential by ID.
+    Unlistable = 0x0001000e,
 
     /// The message type was not enabled.
     NotEnabled = 0x00020000,
@@ -262,6 +267,45 @@ pub enum MessageKind {
 
     /// Lists all allocated ranges of IDs for extensions.
     ListExtensionRanges = 0x00020002,
+
+    /// Open a store and associate an ID with it.
+    OpenStore = 0x00030000,
+
+    /// Close a store and associate an ID with it.
+    CloseStore = 0x00030001,
+
+    /// Lists all elements of a given type in the given store.
+    ListStoreElements = 0x00030002,
+
+    /// Acquire a handle to an element in the given store.
+    AcquireStoreElement = 0x00030003,
+
+    /// Release the handle of a store element.
+    CloseStoreElement = 0x00030004,
+
+    /// Authenticate to a store element if that's required to open it.
+    AuthenticateStoreElement = 0x00030005,
+
+    /// Create a store element.
+    CreateStoreElement = 0x00030006,
+
+    /// Delete a store element.
+    DeleteStoreElement = 0x00030007,
+
+    /// Update a store element.
+    UpdateStoreElement = 0x00030008,
+
+    /// Read a store element.
+    ReadStoreElement = 0x00030009,
+
+    /// Rename a store element.
+    RenameStoreElement = 0x0003000a,
+
+    /// Copy a store element.
+    CopyStoreElement = 0x0003000b,
+
+    /// Search store elements.
+    SearchStoreElements = 0x0003000c,
 }
 
 #[derive(Debug, Hash, Eq, PartialEq, Ord, PartialOrd, Clone)]
@@ -272,6 +316,7 @@ pub enum Capability {
     ChannelSFTP,
     ChannelClipboard,
     ExtensionAllocate,
+    StoreCredential,
     Other(Bytes, Option<Bytes>),
 }
 
@@ -324,6 +369,10 @@ impl From<Capability> for (Bytes, Option<Bytes>) {
                 (b"channel" as &[u8]).into(),
                 Some((b"clipboard" as &[u8]).into()),
             ),
+            Capability::StoreCredential => (
+                (b"store" as &[u8]).into(),
+                Some((b"credential" as &[u8]).into()),
+            ),
             Capability::ExtensionAllocate => (
                 (b"extension" as &[u8]).into(),
                 Some((b"allocate" as &[u8]).into()),
@@ -341,6 +390,7 @@ impl From<(&[u8], Option<&[u8]>)> for Capability {
             (b"channel", Some(b"9p")) => Capability::Channel9P,
             (b"channel", Some(b"sftp")) => Capability::ChannelSFTP,
             (b"channel", Some(b"clipboard")) => Capability::ChannelClipboard,
+            (b"store", Some(b"credential")) => Capability::StoreCredential,
             (b"extension", Some(b"allocate")) => Capability::ExtensionAllocate,
             (name, subtype) => {
                 Capability::Other(name.to_vec().into(), subtype.map(|s| s.to_vec().into()))
@@ -630,6 +680,344 @@ pub enum ClipboardChannelOperation {
     Paste,
 }
 
+#[derive(Serialize, Deserialize, Hash, Debug, Eq, PartialEq, Ord, PartialOrd, Clone, Copy)]
+#[serde(transparent)]
+pub struct StoreID(pub u32);
+
+#[derive(Serialize, Deserialize, Hash, Debug, Eq, PartialEq, Ord, PartialOrd, Clone, Copy)]
+#[serde(transparent)]
+pub struct StoreSelectorID(pub u32);
+
+#[derive(Serialize, Deserialize, Debug, Hash, Eq, PartialEq, Ord, PartialOrd, Clone)]
+#[serde(rename_all = "kebab-case")]
+pub enum StoreSelector {
+    Path(Bytes),
+    #[serde(rename = "id")]
+    ID(StoreSelectorID),
+}
+
+#[derive(Serialize, Deserialize, Eq, PartialEq, Ord, PartialOrd, Clone)]
+#[serde(rename_all = "kebab-case")]
+pub struct OpenStoreRequest {
+    pub kind: Bytes,
+    pub path: Option<Bytes>,
+    pub meta: Option<BTreeMap<Bytes, Value>>,
+}
+
+#[derive(Serialize, Deserialize, Hash, Eq, PartialEq, Ord, PartialOrd, Clone)]
+#[serde(rename_all = "kebab-case")]
+pub struct OpenStoreResponse {
+    pub id: StoreID,
+}
+
+#[derive(Serialize, Deserialize, Hash, Eq, PartialEq, Ord, PartialOrd, Clone)]
+#[serde(rename_all = "kebab-case")]
+pub struct CloseStoreRequest {
+    pub id: StoreID,
+}
+
+#[derive(Serialize, Deserialize, Hash, Eq, PartialEq, Ord, PartialOrd, Clone)]
+#[serde(rename_all = "kebab-case")]
+pub struct ListStoreElementsRequest {
+    pub id: StoreID,
+    pub selector: StoreSelector,
+}
+
+#[derive(Serialize, Deserialize, Eq, PartialEq, Ord, PartialOrd, Clone)]
+#[serde(rename_all = "kebab-case")]
+pub struct ListStoreElementsResponse {
+    pub elements: Vec<StoreElement>,
+}
+
+impl IntoIterator for ListStoreElementsResponse {
+    type Item = StoreElement;
+    type IntoIter = std::vec::IntoIter<StoreElement>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.elements.into_iter()
+    }
+}
+
+impl<'a> IntoIterator for &'a ListStoreElementsResponse {
+    type Item = &'a StoreElement;
+    type IntoIter = std::slice::Iter<'a, StoreElement>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.elements.iter()
+    }
+}
+
+impl<'a> IntoIterator for &'a mut ListStoreElementsResponse {
+    type Item = &'a mut StoreElement;
+    type IntoIter = std::slice::IterMut<'a, StoreElement>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.elements.iter_mut()
+    }
+}
+
+#[derive(Serialize, Deserialize, Hash, Eq, PartialEq, Ord, PartialOrd, Clone)]
+#[serde(rename_all = "kebab-case")]
+pub struct AcquireStoreElementRequest {
+    pub id: StoreID,
+    pub selector: Bytes,
+}
+
+#[derive(Serialize, Deserialize, Hash, Eq, PartialEq, Ord, PartialOrd, Clone)]
+#[serde(rename_all = "kebab-case")]
+pub struct AcquireStoreElementResponse {
+    pub selector: StoreSelectorID,
+}
+
+#[derive(Serialize, Deserialize, Hash, Eq, PartialEq, Ord, PartialOrd, Clone)]
+#[serde(rename_all = "kebab-case")]
+pub struct CloseStoreElementRequest {
+    pub id: StoreID,
+    pub selector: StoreSelectorID,
+}
+
+#[derive(Serialize, Deserialize, Hash, Eq, PartialEq, Ord, PartialOrd, Clone)]
+#[serde(rename_all = "kebab-case")]
+pub struct AuthenticateStoreElementRequest {
+    pub id: StoreID,
+    pub selector: StoreSelectorID,
+    pub method: Bytes,
+    pub message: Option<Bytes>,
+}
+
+#[derive(Serialize, Deserialize, Hash, Eq, PartialEq, Ord, PartialOrd, Clone)]
+#[serde(rename_all = "kebab-case")]
+pub struct AuthenticateStoreElementResponse {
+    pub method: Bytes,
+    pub message: Option<Bytes>,
+}
+
+#[derive(Serialize, Deserialize, Eq, PartialEq, Ord, PartialOrd, Clone)]
+#[serde(rename_all = "kebab-case")]
+pub struct StoreElementBareRequest {
+    pub id: StoreID,
+    pub selector: StoreSelector,
+    pub kind: String,
+    pub needs_authentication: Option<bool>,
+    pub authentication_methods: Option<Vec<Bytes>>,
+    pub meta: Option<BTreeMap<Bytes, Value>>,
+}
+
+#[derive(Serialize, Deserialize, Eq, PartialEq, Ord, PartialOrd, Clone)]
+#[serde(rename_all = "kebab-case")]
+pub struct CreateStoreElementRequest<T> {
+    pub id: StoreID,
+    pub selector: StoreSelector,
+    pub kind: String,
+    pub needs_authentication: Option<bool>,
+    pub authentication_methods: Option<Vec<Bytes>>,
+    pub meta: Option<BTreeMap<Bytes, Value>>,
+    pub body: T,
+}
+
+#[derive(Serialize, Deserialize, Eq, PartialEq, Ord, PartialOrd, Clone)]
+#[serde(rename_all = "kebab-case")]
+pub struct DeleteStoreElementRequest {
+    pub id: StoreID,
+    pub selector: StoreSelector,
+}
+
+#[derive(Serialize, Deserialize, Eq, PartialEq, Ord, PartialOrd, Clone)]
+#[serde(rename_all = "kebab-case")]
+pub struct UpdateStoreElementRequest<T> {
+    pub id: StoreID,
+    pub selector: StoreSelector,
+    pub kind: String,
+    pub needs_authentication: Option<bool>,
+    pub authentication_methods: Option<Vec<Bytes>>,
+    pub meta: Option<BTreeMap<Bytes, Value>>,
+    pub body: T,
+}
+
+#[derive(Serialize, Deserialize, Eq, PartialEq, Ord, PartialOrd, Clone)]
+#[serde(rename_all = "kebab-case")]
+pub struct ReadStoreElementRequest {
+    pub id: StoreID,
+    pub selector: StoreSelector,
+}
+
+#[derive(Serialize, Deserialize, Eq, PartialEq, Ord, PartialOrd, Clone)]
+#[serde(rename_all = "kebab-case")]
+pub struct ReadStoreElementResponse<T> {
+    pub kind: String,
+    pub needs_authentication: Option<bool>,
+    pub authentication_methods: Option<Vec<Bytes>>,
+    pub meta: Option<BTreeMap<Bytes, Value>>,
+    pub body: T,
+}
+
+#[derive(Serialize, Deserialize, Eq, PartialEq, Ord, PartialOrd, Clone)]
+#[serde(rename_all = "kebab-case")]
+pub enum StoreSearchRecursionLevel {
+    Boolean(bool),
+    Levels(u32),
+}
+
+#[derive(Serialize, Deserialize, Eq, PartialEq, Ord, PartialOrd, Clone)]
+#[serde(rename_all = "kebab-case")]
+pub struct SearchStoreElementsBareRequest {
+    pub id: StoreID,
+    pub selector: StoreSelector,
+    pub recurse: StoreSearchRecursionLevel,
+    pub kind: Option<String>,
+}
+
+#[derive(Serialize, Deserialize, Eq, PartialEq, Ord, PartialOrd, Clone)]
+#[serde(rename_all = "kebab-case")]
+pub struct SearchStoreElementsRequest<T> {
+    pub id: StoreID,
+    pub selector: StoreSelector,
+    pub recurse: StoreSearchRecursionLevel,
+    pub kind: Option<String>,
+    pub body: Option<T>,
+}
+
+#[derive(Serialize, Deserialize, Eq, PartialEq, Ord, PartialOrd, Clone)]
+#[serde(rename_all = "kebab-case")]
+pub struct SearchStoreElementsResponse<T> {
+    pub elements: Vec<StoreElementWithBody<T>>,
+}
+
+impl<T> IntoIterator for SearchStoreElementsResponse<T> {
+    type Item = StoreElementWithBody<T>;
+    type IntoIter = std::vec::IntoIter<StoreElementWithBody<T>>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.elements.into_iter()
+    }
+}
+
+impl<'a, T> IntoIterator for &'a SearchStoreElementsResponse<T> {
+    type Item = &'a StoreElementWithBody<T>;
+    type IntoIter = std::slice::Iter<'a, StoreElementWithBody<T>>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.elements.iter()
+    }
+}
+
+impl<'a, T> IntoIterator for &'a mut SearchStoreElementsResponse<T> {
+    type Item = &'a mut StoreElementWithBody<T>;
+    type IntoIter = std::slice::IterMut<'a, StoreElementWithBody<T>>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.elements.iter_mut()
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, Eq, PartialEq, Ord, PartialOrd, Clone)]
+#[serde(rename_all = "kebab-case")]
+pub struct StoreElement {
+    pub path: Bytes,
+    pub id: Option<StoreSelectorID>,
+    pub kind: String,
+    pub needs_authentication: Option<bool>,
+    pub authentication_methods: Option<Vec<Bytes>>,
+    pub meta: Option<BTreeMap<Bytes, Value>>,
+}
+
+#[derive(Serialize, Deserialize, Eq, PartialEq, Ord, PartialOrd, Clone)]
+#[serde(rename_all = "kebab-case")]
+pub struct StoreElementWithBody<T> {
+    pub path: Bytes,
+    pub id: Option<StoreSelectorID>,
+    pub kind: String,
+    pub needs_authentication: Option<bool>,
+    pub authentication_methods: Option<Vec<Bytes>>,
+    pub meta: Option<BTreeMap<Bytes, Value>>,
+    pub body: T,
+}
+
+impl<T> StoreElementWithBody<T> {
+    pub fn new(elem: StoreElement, body: T) -> Self {
+        Self {
+            path: elem.path,
+            id: elem.id,
+            kind: elem.kind,
+            needs_authentication: elem.needs_authentication,
+            authentication_methods: elem.authentication_methods,
+            meta: elem.meta,
+            body,
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, Eq, PartialEq, Ord, PartialOrd, Clone)]
+#[serde(rename_all = "kebab-case")]
+pub enum SearchStoreElementType {
+    Literal(Value),
+    Set(BTreeSet<SearchStoreElementType>),
+    Sequence(Vec<SearchStoreElementType>),
+    // The unit value here exists to keep the same form across all serializations.
+    Any(()),
+    None(()),
+}
+
+#[derive(Serialize, Deserialize, Eq, PartialEq, Ord, PartialOrd, Clone, Debug)]
+#[serde(rename_all = "kebab-case")]
+pub struct CredentialStoreSearchElement {
+    pub username: SearchStoreElementType,
+    pub secret: SearchStoreElementType,
+    pub authtype: SearchStoreElementType,
+    pub kind: SearchStoreElementType,
+    pub protocol: SearchStoreElementType,
+    pub host: SearchStoreElementType,
+    pub title: SearchStoreElementType,
+    pub description: SearchStoreElementType,
+    pub path: SearchStoreElementType,
+    pub service: SearchStoreElementType,
+    pub extra: BTreeMap<String, SearchStoreElementType>,
+    pub id: SearchStoreElementType,
+}
+
+#[derive(Serialize, Deserialize, Debug, Eq, PartialEq, Ord, PartialOrd, Clone)]
+#[serde(rename_all = "kebab-case")]
+pub struct CredentialStoreLocation {
+    pub protocol: Option<String>,
+    pub host: Option<String>,
+    pub port: Option<u16>,
+    pub path: Option<String>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Eq, PartialEq, Ord, PartialOrd, Clone)]
+#[serde(rename_all = "kebab-case")]
+pub struct CredentialStoreElement {
+    pub username: Option<Bytes>,
+    pub secret: Option<Bytes>,
+    pub authtype: Option<String>,
+    #[serde(rename = "type")]
+    pub kind: String,
+    pub title: Option<String>,
+    pub description: Option<String>,
+    pub location: Vec<CredentialStoreLocation>,
+    pub service: Option<String>,
+    pub extra: BTreeMap<String, Value>,
+    pub id: Bytes,
+}
+
+#[derive(Serialize, Deserialize, Debug, Eq, PartialEq, Ord, PartialOrd, Clone)]
+pub struct KeyboardInteractiveAuthenticationPrompt {
+    pub prompt: String,
+    pub echo: bool,
+}
+
+#[derive(Serialize, Deserialize, Debug, Eq, PartialEq, Ord, PartialOrd, Clone)]
+pub struct KeyboardInteractiveAuthenticationRequest {
+    pub name: String,
+    pub instruction: String,
+    pub prompts: Vec<KeyboardInteractiveAuthenticationPrompt>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Eq, PartialEq, Ord, PartialOrd, Clone)]
+pub struct KeyboardInteractiveAuthenticationResponse {
+    pub responses: Vec<String>,
+}
+
 /// A message for the protocol.
 #[derive(Clone, Debug)]
 pub struct Message {
@@ -861,9 +1249,13 @@ impl ProtocolSerializer {
 
 #[cfg(test)]
 mod tests {
-    use super::{ChannelID, Empty, Message, ProtocolSerializer, Response, ResponseValue};
+    use super::{
+        ChannelID, Empty, Message, ProtocolSerializer, Response, ResponseValue,
+        SearchStoreElementType, StoreID, StoreSelector, StoreSelectorID,
+    };
     use bytes::Bytes;
     use serde::{de::DeserializeOwned, Deserialize, Serialize};
+    use serde_cbor::Value;
     use std::convert::TryFrom;
     use std::fmt::Debug;
 
@@ -1006,6 +1398,53 @@ mod tests {
             "ChannelID all ones u32",
             &ChannelID(0xfedcba98u32),
             b"\x1a\xfe\xdc\xba\x98",
+        );
+        assert_round_trip("StoreID 0", &StoreID(0), b"\x00");
+        assert_round_trip(
+            "StoreID pattern",
+            &StoreID(0xfedcba98u32),
+            b"\x1a\xfe\xdc\xba\x98",
+        );
+        assert_round_trip("StoreSelectorID 0", &StoreSelectorID(0), b"\x00");
+        assert_round_trip(
+            "StoreSelectorID pattern",
+            &StoreSelectorID(0xfedcba98u32),
+            b"\x1a\xfe\xdc\xba\x98",
+        );
+        assert_round_trip(
+            "StoreSelector path",
+            &StoreSelector::Path(Bytes::from(b"/dev/null" as &[u8])),
+            b"\xa1\x64path\x49/dev/null",
+        );
+        assert_round_trip(
+            "StoreSelector ID",
+            &StoreSelector::ID(StoreSelectorID(0xfedcba98u32)),
+            b"\xa1\x62id\x1a\xfe\xdc\xba\x98",
+        );
+        assert_round_trip(
+            "SearchStoreElementType literal text",
+            &SearchStoreElementType::Literal(Value::Text(String::from("abc123"))),
+            b"\xa1\x67literal\x66abc123",
+        );
+        assert_round_trip(
+            "SearchStoreElementType literal bytes",
+            &SearchStoreElementType::Literal(Value::Bytes("abc123".into())),
+            b"\xa1\x67literal\x46abc123",
+        );
+        assert_round_trip(
+            "SearchStoreElementType literal null",
+            &SearchStoreElementType::Literal(Value::Null),
+            b"\xa1\x67literal\xf6",
+        );
+        assert_round_trip(
+            "SearchStoreElementType any",
+            &SearchStoreElementType::Any(()),
+            b"\xa1\x63any\xf6",
+        );
+        assert_round_trip(
+            "SearchStoreElementType none",
+            &SearchStoreElementType::None(()),
+            b"\xa1\x64none\xf6",
         );
     }
 

--- a/lawn-protocol/src/protocol/mod.rs
+++ b/lawn-protocol/src/protocol/mod.rs
@@ -311,6 +311,8 @@ pub enum MessageKind {
 #[derive(Debug, Hash, Eq, PartialEq, Ord, PartialOrd, Clone)]
 pub enum Capability {
     AuthExternal,
+    AuthKeyboardInteractive,
+    AuthPlain,
     ChannelCommand,
     Channel9P,
     ChannelSFTP,
@@ -325,6 +327,8 @@ impl Capability {
     pub fn implemented() -> BTreeSet<Capability> {
         [
             Self::AuthExternal,
+            Self::AuthKeyboardInteractive,
+            Self::AuthPlain,
             Self::ChannelCommand,
             Self::ChannelClipboard,
             Self::Channel9P,
@@ -341,6 +345,8 @@ impl Capability {
         matches!(
             self,
             Self::AuthExternal
+                | Self::AuthKeyboardInteractive
+                | Self::AuthPlain
                 | Self::ChannelCommand
                 | Self::ChannelClipboard
                 | Self::Channel9P
@@ -358,6 +364,11 @@ impl From<Capability> for (Bytes, Option<Bytes>) {
                 (b"auth" as &[u8]).into(),
                 Some((b"EXTERNAL" as &[u8]).into()),
             ),
+            Capability::AuthKeyboardInteractive => (
+                (b"auth" as &[u8]).into(),
+                Some((b"keyboard-interactive" as &[u8]).into()),
+            ),
+            Capability::AuthPlain => ((b"auth" as &[u8]).into(), Some((b"PLAIN" as &[u8]).into())),
             Capability::ChannelCommand => (
                 (b"channel" as &[u8]).into(),
                 Some((b"command" as &[u8]).into()),
@@ -388,6 +399,8 @@ impl From<(&[u8], Option<&[u8]>)> for Capability {
     fn from(data: (&[u8], Option<&[u8]>)) -> Capability {
         match data {
             (b"auth", Some(b"EXTERNAL")) => Capability::AuthExternal,
+            (b"auth", Some(b"PLAIN")) => Capability::AuthPlain,
+            (b"auth", Some(b"keyboard-interactive")) => Capability::AuthKeyboardInteractive,
             (b"channel", Some(b"command")) => Capability::ChannelCommand,
             (b"channel", Some(b"9p")) => Capability::Channel9P,
             (b"channel", Some(b"sftp")) => Capability::ChannelSFTP,

--- a/lawn-protocol/src/protocol/mod.rs
+++ b/lawn-protocol/src/protocol/mod.rs
@@ -107,7 +107,7 @@ pub enum ResponseCode {
 
     /// The message type was not enabled.
     NotEnabled = 0x00020000,
-    /// The message type was not supported.
+    /// The message type or operation was not supported.
     NotSupported = 0x00020001,
     /// The parameters were not supported.
     ParametersNotSupported = 0x00020002,
@@ -330,6 +330,7 @@ impl Capability {
             Self::Channel9P,
             Self::ChannelSFTP,
             Self::ExtensionAllocate,
+            Self::StoreCredential,
         ]
         .iter()
         .cloned()
@@ -345,6 +346,7 @@ impl Capability {
                 | Self::Channel9P
                 | Self::ChannelSFTP
                 | Self::ExtensionAllocate
+                | Self::StoreCredential
         )
     }
 }

--- a/lawn/Cargo.toml
+++ b/lawn/Cargo.toml
@@ -28,6 +28,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_cbor = "0.11"
 serde_json = "1.0"
 serde_yaml = "0.8"
+format-bytes = "0.3"
 libc = "0.2"
 signal-hook-tokio = "0.3"
 lawn-constants = { path = "../lawn-constants", version = "0.3.0" }

--- a/lawn/Cargo.toml
+++ b/lawn/Cargo.toml
@@ -20,10 +20,13 @@ name = "lawn"
 path = "src/main.rs"
 
 [dependencies]
+async-trait = "= 0.1.66"
+blake2 = "0.10"
 bytes = "1"
 clap = "2.32"
 serde = { version = "1.0", features = ["derive"] }
 serde_cbor = "0.11"
+serde_json = "1.0"
 serde_yaml = "0.8"
 libc = "0.2"
 signal-hook-tokio = "0.3"
@@ -32,8 +35,11 @@ lawn-9p = { path = "../lawn-9p", version = "0.3.0", features = ["unix"] }
 lawn-fs = { path = "../lawn-fs", version = "0.3.0", features = ["unix"] }
 lawn-protocol = { path = "../lawn-protocol", version = "0.3.0", features = ["async"] }
 lawn-sftp = { path = "../lawn-sftp", version = "0.3.0" }
+subtle = "2"
 tokio = { version = "1", features = [ "io-std", "macros", "net", "process", "rt", "rt-multi-thread", "signal", "time" ] }
 tokio-pipe = "0.2"
+thiserror = "1.0.39"
+url = "2.2"
 daemonize = "0.4"
 num-traits = "0.2"
 num-derive = "0.3"

--- a/lawn/src/client.rs
+++ b/lawn/src/client.rs
@@ -146,7 +146,7 @@ impl Connection {
             .capabilities
             .iter()
             .cloned()
-            .filter_map(|c| c.try_into().ok())
+            .map(|c| c.into())
             .collect();
         let intersection = ours
             .intersection(&theirs)

--- a/lawn/src/client.rs
+++ b/lawn/src/client.rs
@@ -103,6 +103,10 @@ impl Connection {
         })
     }
 
+    pub(crate) fn config(&self) -> Arc<Config> {
+        self.config.clone()
+    }
+
     pub async fn ping(&self) -> Result<(), Error> {
         self.handler
             .send_message_simple::<Empty, Empty>(MessageKind::Ping, Some(true))

--- a/lawn/src/config.rs
+++ b/lawn/src/config.rs
@@ -743,7 +743,7 @@ impl Config {
         logger: &Logger,
         env: E,
     ) -> Option<PathBuf> {
-        match Self::find_runtime_dirs(logger, env).get(0) {
+        match Self::find_runtime_dirs(logger, env).first() {
             Some(s) => Some(s.clone()),
             None => {
                 trace!(logger, "runtime_dir: unable to find runtime directory");

--- a/lawn/src/config.rs
+++ b/lawn/src/config.rs
@@ -310,6 +310,7 @@ impl Config {
             senv: Some(self.env_vars.clone()),
             cenv,
             args,
+            ctxsenv: None,
         }
     }
 
@@ -1011,6 +1012,14 @@ pub fn command_from_args(args: &[Bytes], context: &TemplateContext) -> tokio::pr
             )
         }));
     }
+    if let Some(ctxsenv) = &context.ctxsenv {
+        cmd.envs(ctxsenv.iter().map(|(k, v)| {
+            (
+                OsString::from_vec(k.to_vec()),
+                OsString::from_vec(v.to_vec()),
+            )
+        }));
+    }
     cmd.current_dir("/");
     cmd
 }
@@ -1032,6 +1041,14 @@ pub fn std_command_from_args(args: &[Bytes], context: &TemplateContext) -> std::
     if let Some(senv) = &context.senv {
         cmd.env_clear();
         cmd.envs(senv.iter().map(|(k, v)| {
+            (
+                OsString::from_vec(k.to_vec()),
+                OsString::from_vec(v.to_vec()),
+            )
+        }));
+    }
+    if let Some(ctxsenv) = &context.ctxsenv {
+        cmd.envs(ctxsenv.iter().map(|(k, v)| {
             (
                 OsString::from_vec(k.to_vec()),
                 OsString::from_vec(v.to_vec()),

--- a/lawn/src/config.rs
+++ b/lawn/src/config.rs
@@ -99,6 +99,7 @@ pub struct CredentialBackend {
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum CredentialBackendType {
     Git { command: String },
+    Memory { token: Option<String> },
     Other,
 }
 
@@ -538,6 +539,19 @@ impl Config {
                                 return Err(Error::new_with_message(
                                     ErrorKind::InvalidConfigurationValue,
                                     "credential type \"git\" requires the option \"command\"",
+                                ))
+                            }
+                        },
+                        ("memory", None) => CredentialBackendType::Memory { token: None },
+                        ("memory", Some(opts)) => match opts.get("token") {
+                            Some(Value::String(ref s)) => {
+                                CredentialBackendType::Memory { token: Some(s.clone()) }
+                            },
+                            None => CredentialBackendType::Memory { token: None },
+                            _ => {
+                                return Err(Error::new_with_message(
+                                    ErrorKind::InvalidConfigurationValue,
+                                    "credential type \"memory\" requires the option \"token\" to be a string",
                                 ))
                             }
                         },

--- a/lawn/src/credential.rs
+++ b/lawn/src/credential.rs
@@ -29,6 +29,8 @@ use std::io;
 use std::sync::Arc;
 use thiserror::Error;
 
+pub mod protocol;
+
 #[derive(Debug, Error)]
 pub enum CredentialError {
     #[error("empty response {0}")]

--- a/lawn/src/credential.rs
+++ b/lawn/src/credential.rs
@@ -1,0 +1,1691 @@
+use crate::client::Connection;
+use crate::error::MissingElementError;
+use crate::task::block_on_async;
+use async_trait::async_trait;
+use blake2::Digest;
+use bytes::Bytes;
+use format_bytes::format_bytes;
+use lawn_constants::logger::AsLogStr;
+use lawn_protocol::handler;
+use lawn_protocol::protocol::Error as ProtocolError;
+use lawn_protocol::protocol::{
+    AcquireStoreElementRequest, AcquireStoreElementResponse, AuthenticateStoreElementRequest,
+    AuthenticateStoreElementResponse, CloseStoreRequest, ContinueRequest,
+    CreateStoreElementRequest, CredentialStoreElement, CredentialStoreLocation,
+    CredentialStoreSearchElement, DeleteStoreElementRequest, Empty, ListStoreElementsRequest,
+    ListStoreElementsResponse, MessageKind, OpenStoreRequest, OpenStoreResponse,
+    ReadStoreElementRequest, ReadStoreElementResponse, ResponseCode, ResponseValue,
+    SearchStoreElementType, SearchStoreElementsRequest, SearchStoreElementsResponse, StoreElement,
+    StoreElementWithBody, StoreID, StoreSearchRecursionLevel, StoreSelector, StoreSelectorID,
+    UpdateStoreElementRequest,
+};
+use serde::{Deserialize, Serialize};
+use serde_cbor::Value;
+use std::borrow::Cow;
+use std::collections::{BTreeMap, BTreeSet};
+use std::convert::{TryFrom, TryInto};
+use std::fmt;
+use std::io;
+use std::sync::Arc;
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum CredentialError {
+    #[error("empty response {0}")]
+    EmptyResponse(Cow<'static, str>),
+    #[error("protocol failure: {0}")]
+    ProtocolFailure(#[from] crate::error::Error),
+    #[error("not found")]
+    NotFound,
+    #[error("conflict")]
+    Conflict,
+    #[error("unsupported serialization")]
+    UnsupportedSerialization,
+}
+
+struct ConnectionWrapper {
+    conn: Arc<Connection>,
+    id: StoreID,
+}
+
+impl ConnectionWrapper {
+    #[allow(dead_code)]
+    fn new(conn: Arc<Connection>, id: StoreID) -> Self {
+        Self { conn, id }
+    }
+
+    fn store_id(&self) -> StoreID {
+        self.id
+    }
+
+    fn connection(&self) -> Arc<Connection> {
+        self.conn.clone()
+    }
+}
+
+impl Drop for ConnectionWrapper {
+    fn drop(&mut self) {
+        let id = self.id;
+        let conn = self.conn.clone();
+        block_on_async(async move {
+            let req = CloseStoreRequest { id };
+            let _ = conn
+                .send_message_simple::<_, Empty>(MessageKind::CloseStore, Some(req))
+                .await;
+        });
+    }
+}
+
+pub struct CredentialClient {
+    conn: Arc<ConnectionWrapper>,
+    handle: CredentialDirectoryHandle,
+}
+
+impl CredentialClient {
+    #[allow(dead_code)]
+    pub async fn new(conn: Arc<Connection>) -> Result<Self, CredentialError> {
+        let req = OpenStoreRequest {
+            kind: Bytes::from(b"credential" as &[u8]),
+            path: None,
+            meta: None,
+        };
+        let resp: OpenStoreResponse = conn
+            .send_message_simple(MessageKind::OpenStore, Some(req))
+            .await?
+            .ok_or_else(|| {
+                CredentialError::EmptyResponse("when opening credential store".into())
+            })?;
+        let cw = Arc::new(ConnectionWrapper::new(conn, resp.id));
+        let path = Bytes::from(b"/" as &[u8]);
+        let id = Self::acquire_handle(cw.clone(), resp.id, path.clone()).await?;
+        let handle = CredentialDirectoryHandle {
+            path,
+            id: Some(id),
+            conn: cw.clone(),
+            store_id: resp.id,
+        };
+        Ok(Self { conn: cw, handle })
+    }
+
+    // This is used in tests.
+    #[allow(dead_code)]
+    async fn list_store_elements(
+        conn: Arc<ConnectionWrapper>,
+        id: StoreID,
+        selector: StoreSelector,
+    ) -> Result<Option<Vec<StoreElement>>, CredentialError> {
+        let req = ListStoreElementsRequest { id, selector };
+        Ok(conn
+            .connection()
+            .send_pagination_message::<StoreElement, _, ListStoreElementsResponse>(
+                MessageKind::ListStoreElements,
+                Some(req),
+            )
+            .await?)
+    }
+
+    async fn acquire_handle(
+        conn: Arc<ConnectionWrapper>,
+        id: StoreID,
+        path: Bytes,
+    ) -> Result<StoreSelectorID, CredentialError> {
+        let req = AcquireStoreElementRequest { id, selector: path };
+        let resp: AcquireStoreElementResponse = match conn
+            .connection()
+            .send_message_simple(MessageKind::AcquireStoreElement, Some(req))
+            .await?
+        {
+            Some(resp) => resp,
+            None => {
+                return Err(CredentialError::EmptyResponse(
+                    "when acquiring handle".into(),
+                ))
+            }
+        };
+        Ok(resp.selector)
+    }
+
+    /// List the credential stores that are available.
+    // This is used in tests.
+    #[allow(dead_code)]
+    pub async fn list_stores(&self) -> Result<Vec<CredentialStore>, CredentialError> {
+        let resp = Self::list_store_elements(
+            self.conn.clone(),
+            self.conn.store_id(),
+            StoreSelector::Path(Bytes::from(b"/" as &[u8])),
+        )
+        .await?;
+        match resp {
+            Some(v) => Ok(v
+                .iter()
+                .map(|se| CredentialStore {
+                    handle: CredentialDirectoryHandle {
+                        path: se.path.clone(),
+                        id: None,
+                        conn: self.conn.clone(),
+                        store_id: self.conn.store_id(),
+                    },
+                })
+                .collect()),
+            None => Err(CredentialError::EmptyResponse(
+                "when listing credential stores".into(),
+            )),
+        }
+    }
+}
+
+#[async_trait]
+impl CredentialHandle for CredentialClient {
+    async fn authenticate(
+        &mut self,
+        last_id: Option<u32>,
+        method: &[u8],
+        message: Option<Bytes>,
+    ) -> Result<(Option<u32>, Option<Bytes>), CredentialError> {
+        self.handle.authenticate(last_id, method, message).await
+    }
+
+    async fn list_entries<'a>(
+        &'a self,
+    ) -> Result<Box<dyn Iterator<Item = StoreElement> + 'a>, CredentialError> {
+        self.handle.list_entries().await
+    }
+
+    async fn search_entry(
+        &self,
+        req: &CredentialRequest,
+        recurse: StoreSearchRecursionLevel,
+    ) -> Result<Option<Credential>, CredentialError> {
+        self.handle.search_entry(req, recurse).await
+    }
+
+    async fn get_entry(&self, component: &[u8]) -> Result<Option<Credential>, CredentialError> {
+        self.handle.get_entry(component).await
+    }
+
+    async fn create_entry(&self, req: &Credential) -> Result<(), CredentialError> {
+        self.handle.create_entry(req).await
+    }
+
+    async fn update_entry(&self, req: &Credential) -> Result<(), CredentialError> {
+        self.handle.update_entry(req).await
+    }
+
+    async fn put_entry(&self, req: &Credential) -> Result<(), CredentialError> {
+        self.handle.put_entry(req).await
+    }
+
+    async fn delete_entry(&self, req: &Credential) -> Result<(), CredentialError> {
+        self.handle.delete_entry(req).await
+    }
+
+    async fn path(&self) -> Bytes {
+        self.handle.path().await
+    }
+}
+
+struct CredentialDirectoryHandle {
+    path: Bytes,
+    id: Option<StoreSelectorID>,
+    conn: Arc<ConnectionWrapper>,
+    store_id: StoreID,
+}
+
+impl fmt::Debug for CredentialDirectoryHandle {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+        f.debug_struct("CredentialDirectoryHandle")
+            .field("path", &self.path.as_ref().as_log_str())
+            .field("id", &self.id)
+            .field("store_id", &self.store_id)
+            .finish()
+    }
+}
+
+impl CredentialDirectoryHandle {
+    async fn get_id_mut(&mut self) -> Result<StoreSelectorID, CredentialError> {
+        match self.id {
+            Some(id) => Ok(id),
+            None => {
+                let id = CredentialClient::acquire_handle(
+                    self.conn.clone(),
+                    self.store_id,
+                    self.path.clone(),
+                )
+                .await?;
+                self.id = Some(id);
+                Ok(id)
+            }
+        }
+    }
+
+    async fn get_id(&self) -> Result<StoreSelectorID, CredentialError> {
+        match self.id {
+            Some(id) => Ok(id),
+            None => {
+                let id = CredentialClient::acquire_handle(
+                    self.conn.clone(),
+                    self.store_id,
+                    self.path.clone(),
+                )
+                .await?;
+                Ok(id)
+            }
+        }
+    }
+
+    /// List the credential stores that are available.
+    // This is used in tests.
+    #[allow(dead_code)]
+    pub async fn list_directories(&self) -> Result<Vec<CredentialDirectory>, CredentialError> {
+        let resp = CredentialClient::list_store_elements(
+            self.conn.clone(),
+            self.store_id,
+            StoreSelector::Path(self.path.clone()),
+        )
+        .await?;
+        match resp {
+            Some(v) => Ok(v
+                .iter()
+                .filter_map(|se| {
+                    if se.kind == "directory" && se.path.ends_with(b"/") {
+                        Some(CredentialDirectory {
+                            handle: CredentialDirectoryHandle {
+                                path: se.path.clone(),
+                                id: None,
+                                conn: self.conn.clone(),
+                                store_id: self.store_id,
+                            },
+                        })
+                    } else {
+                        None
+                    }
+                })
+                .collect()),
+            None => Err(CredentialError::EmptyResponse(
+                "when listing credential directories".into(),
+            )),
+        }
+    }
+
+    #[allow(dead_code)]
+    pub async fn create_directory(
+        &self,
+        name: &[u8],
+    ) -> Result<CredentialDirectoryHandle, CredentialError> {
+        let path: Bytes = format_bytes!(b"{}{}/", self.path.as_ref(), name).into();
+        let logger = self.conn.connection().config().logger();
+        trace!(
+            logger,
+            "credential: creating directory {}",
+            path.as_ref().as_log_str()
+        );
+        let req = CreateStoreElementRequest {
+            id: self.store_id,
+            selector: StoreSelector::Path(path.clone()),
+            kind: "directory".into(),
+            needs_authentication: None,
+            authentication_methods: None,
+            meta: None,
+            body: (),
+        };
+        let resp: StoreElement = self
+            .conn
+            .connection()
+            .send_message_simple(MessageKind::CreateStoreElement, Some(req))
+            .await?
+            .ok_or_else(|| {
+                CredentialError::EmptyResponse("when creating credential store".into())
+            })?;
+        Ok(CredentialDirectoryHandle {
+            path: resp.path,
+            id: resp.id,
+            conn: self.conn.clone(),
+            store_id: self.store_id,
+        })
+    }
+}
+
+#[async_trait]
+impl CredentialHandle for CredentialDirectoryHandle {
+    async fn authenticate(
+        &mut self,
+        last_id: Option<u32>,
+        method: &[u8],
+        message: Option<Bytes>,
+    ) -> Result<(Option<u32>, Option<Bytes>), CredentialError> {
+        let id = self.get_id_mut().await?;
+        let req = AuthenticateStoreElementRequest {
+            id: self.store_id,
+            selector: id,
+            method: Bytes::copy_from_slice(method),
+            message,
+        };
+        let resp = if let Some(id) = last_id {
+            let req = ContinueRequest {
+                id,
+                kind: MessageKind::AuthenticateStoreElement as u32,
+                message: Some(req),
+            };
+            self
+                .conn
+                .connection()
+                .send_message::<_, AuthenticateStoreElementResponse, AuthenticateStoreElementResponse>(
+                    MessageKind::Continue,
+                    Some(&req),
+                )
+                .await?
+        } else {
+            self
+                .conn
+                .connection()
+                .send_message::<_, AuthenticateStoreElementResponse, AuthenticateStoreElementResponse>(
+                    MessageKind::AuthenticateStoreElement,
+                    Some(&req),
+                )
+                .await?
+        };
+        match (resp, last_id) {
+            (Some(ResponseValue::Success(m)), _) => Ok((None, m.message)),
+            (Some(ResponseValue::Continuation((_, m))), Some(lid)) => Ok((Some(lid), m.message)),
+            (Some(ResponseValue::Continuation((id, m))), None) => Ok((Some(id), m.message)),
+            (None, _) => return Err(CredentialError::UnsupportedSerialization),
+        }
+    }
+
+    async fn list_entries<'a>(
+        &'a self,
+    ) -> Result<Box<dyn Iterator<Item = StoreElement> + 'a>, CredentialError> {
+        let id = self.get_id().await?;
+        let req = ListStoreElementsRequest {
+            id: self.store_id,
+            selector: StoreSelector::ID(id),
+        };
+        let resp = self
+            .conn
+            .connection()
+            .send_pagination_message::<StoreElement, _, ListStoreElementsResponse>(
+                MessageKind::ListStoreElements,
+                Some(&req),
+            )
+            .await?;
+        let resp = resp.ok_or(CredentialError::UnsupportedSerialization)?;
+        Ok(Box::new(resp.into_iter()))
+    }
+
+    async fn search_entry(
+        &self,
+        req: &CredentialRequest,
+        recurse: StoreSearchRecursionLevel,
+    ) -> Result<Option<Credential>, CredentialError> {
+        let req: SearchStoreElementsRequest<CredentialStoreSearchElement> =
+            SearchStoreElementsRequest {
+                id: self.store_id,
+                selector: match self.id {
+                    Some(id) => StoreSelector::ID(id),
+                    None => StoreSelector::Path(self.path.clone()),
+                },
+                recurse,
+                kind: Some("credential".into()),
+                body: Some(req.into()),
+            };
+        let resp = self.conn.connection()
+            .send_pagination_message::<StoreElementWithBody<CredentialStoreElement>, _, SearchStoreElementsResponse<CredentialStoreElement>>(
+                MessageKind::SearchStoreElements,
+                Some(req),
+            )
+            .await?;
+        resp.and_then(|r| {
+            Some(
+                (&r.first()?.body)
+                    .try_into()
+                    .map_err(|_| CredentialError::UnsupportedSerialization),
+            )
+        })
+        .transpose()
+    }
+
+    async fn get_entry(&self, component: &[u8]) -> Result<Option<Credential>, CredentialError> {
+        let path = format_bytes!(b"{}{}", self.path().await.as_ref(), component);
+        let logger = self.conn.connection().config().logger();
+        trace!(
+            logger,
+            "credential: fetching entry {}",
+            path.as_slice().as_log_str()
+        );
+        let req = ReadStoreElementRequest {
+            id: self.store_id,
+            selector: StoreSelector::Path(path.into()),
+        };
+        match self
+            .conn
+            .connection()
+            .send_message_simple::<_, ReadStoreElementResponse<CredentialStoreElement>>(
+                MessageKind::ReadStoreElement,
+                Some(req),
+            )
+            .await
+        {
+            Ok(Some(elem)) => match elem.body.try_into() {
+                Ok(cred) => Ok(Some(cred)),
+                Err(_) => Err(CredentialError::UnsupportedSerialization),
+            },
+            Ok(None) => Err(CredentialError::UnsupportedSerialization),
+            Err(e) => match ProtocolError::try_from(e) {
+                Ok(pe) if pe.code == ResponseCode::NotFound => Ok(None),
+                Ok(pe) => Err(crate::error::Error::from(handler::Error::from(pe)).into()),
+                Err(e) => Err(e.0.into()),
+            },
+        }
+    }
+
+    async fn create_entry(&self, req: &Credential) -> Result<(), CredentialError> {
+        let req: CreateStoreElementRequest<CredentialStoreElement> = CreateStoreElementRequest {
+            id: self.store_id,
+            needs_authentication: Some(false),
+            authentication_methods: None,
+            selector: StoreSelector::Path(self.path.clone()),
+            meta: None,
+            kind: "credential".into(),
+            body: req.into(),
+        };
+        match self
+            .conn
+            .connection()
+            .send_message_simple::<_, Empty>(MessageKind::CreateStoreElement, Some(req))
+            .await
+        {
+            Ok(_) => Ok(()),
+            Err(e) => match ProtocolError::try_from(e) {
+                Ok(pe) if pe.code == ResponseCode::Conflict => Err(CredentialError::Conflict),
+                Ok(pe) => Err(crate::error::Error::from(handler::Error::from(pe)).into()),
+                Err(e) => Err(e.0.into()),
+            },
+        }
+    }
+
+    async fn update_entry(&self, req: &Credential) -> Result<(), CredentialError> {
+        let req: UpdateStoreElementRequest<CredentialStoreElement> = UpdateStoreElementRequest {
+            id: self.store_id,
+            needs_authentication: Some(false),
+            authentication_methods: None,
+            selector: match self.id {
+                Some(id) => StoreSelector::ID(id),
+                None => StoreSelector::Path(self.path.clone()),
+            },
+            meta: None,
+            kind: "credential".into(),
+            body: req.into(),
+        };
+        match self
+            .conn
+            .connection()
+            .send_message_simple::<_, Empty>(MessageKind::UpdateStoreElement, Some(req))
+            .await
+        {
+            Ok(_) => Ok(()),
+            Err(e) => match ProtocolError::try_from(e) {
+                Ok(pe) if pe.code == ResponseCode::NotFound => Err(CredentialError::NotFound),
+                Ok(pe) => Err(crate::error::Error::from(handler::Error::from(pe)).into()),
+                Err(e) => Err(e.0.into()),
+            },
+        }
+    }
+
+    async fn put_entry(&self, req: &Credential) -> Result<(), CredentialError> {
+        match self.create_entry(req).await {
+            Ok(()) => Ok(()),
+            Err(CredentialError::Conflict) => self.update_entry(req).await,
+            Err(e) => Err(e),
+        }
+    }
+
+    async fn delete_entry(&self, req: &Credential) -> Result<(), CredentialError> {
+        let req = req.to_request();
+        let req: SearchStoreElementsRequest<CredentialStoreSearchElement> =
+            SearchStoreElementsRequest {
+                id: self.store_id,
+                selector: match self.id {
+                    Some(id) => StoreSelector::ID(id),
+                    None => StoreSelector::Path(self.path.clone()),
+                },
+                recurse: StoreSearchRecursionLevel::Boolean(true),
+                kind: Some("credential".into()),
+                body: Some(req.into()),
+            };
+        let resp = self.conn
+            .connection()
+            .send_pagination_message::<StoreElementWithBody<CredentialStoreElement>, _, SearchStoreElementsResponse<CredentialStoreElement>>(
+                MessageKind::SearchStoreElements,
+                Some(req),
+            )
+            .await?;
+        let id = resp
+            .and_then(|r| r.first()?.id)
+            .ok_or(CredentialError::UnsupportedSerialization)?;
+        let req = DeleteStoreElementRequest {
+            id: self.store_id,
+            selector: StoreSelector::ID(id),
+        };
+        match self
+            .conn
+            .connection()
+            .send_message_simple::<_, Empty>(MessageKind::DeleteStoreElement, Some(req))
+            .await
+        {
+            Ok(_) => Ok(()),
+            Err(e) => Err(e.into()),
+        }
+    }
+
+    async fn path(&self) -> Bytes {
+        self.path.clone()
+    }
+}
+
+/// A storage method for credentials.
+///
+/// This corresponds to a given backend type.  For example, one might use the system keychain plus
+/// a password manager, and each of those would be implemented as an struct implementing
+/// `CredentialStore`.
+#[derive(Debug)]
+pub struct CredentialStore {
+    handle: CredentialDirectoryHandle,
+}
+
+impl CredentialStore {
+    /// List the credential stores that are available.
+    #[allow(dead_code)]
+    pub async fn list_vaults(&self) -> Result<Vec<CredentialVault>, CredentialError> {
+        let resp = CredentialClient::list_store_elements(
+            self.handle.conn.clone(),
+            self.handle.store_id,
+            StoreSelector::Path(self.handle.path.clone()),
+        )
+        .await?;
+        match resp {
+            Some(v) => Ok(v
+                .iter()
+                .map(|se| CredentialVault {
+                    handle: CredentialDirectoryHandle {
+                        path: se.path.clone(),
+                        id: None,
+                        conn: self.handle.conn.clone(),
+                        store_id: self.handle.store_id,
+                    },
+                })
+                .collect()),
+            None => Err(CredentialError::EmptyResponse(
+                "when listing credential stores".into(),
+            )),
+        }
+    }
+
+    #[allow(dead_code)]
+    pub async fn create_vault(&self, name: &[u8]) -> Result<CredentialVault, CredentialError> {
+        let handle = self.handle.create_directory(name).await?;
+        Ok(CredentialVault { handle })
+    }
+}
+
+#[async_trait]
+impl CredentialHandle for CredentialStore {
+    async fn authenticate(
+        &mut self,
+        last_id: Option<u32>,
+        method: &[u8],
+        message: Option<Bytes>,
+    ) -> Result<(Option<u32>, Option<Bytes>), CredentialError> {
+        self.handle.authenticate(last_id, method, message).await
+    }
+
+    async fn list_entries<'a>(
+        &'a self,
+    ) -> Result<Box<dyn Iterator<Item = StoreElement> + 'a>, CredentialError> {
+        self.handle.list_entries().await
+    }
+
+    async fn search_entry(
+        &self,
+        req: &CredentialRequest,
+        recurse: StoreSearchRecursionLevel,
+    ) -> Result<Option<Credential>, CredentialError> {
+        self.handle.search_entry(req, recurse).await
+    }
+
+    async fn get_entry(&self, component: &[u8]) -> Result<Option<Credential>, CredentialError> {
+        self.handle.get_entry(component).await
+    }
+
+    async fn create_entry(&self, req: &Credential) -> Result<(), CredentialError> {
+        self.handle.create_entry(req).await
+    }
+
+    async fn update_entry(&self, req: &Credential) -> Result<(), CredentialError> {
+        self.handle.update_entry(req).await
+    }
+
+    async fn put_entry(&self, req: &Credential) -> Result<(), CredentialError> {
+        self.handle.put_entry(req).await
+    }
+
+    async fn delete_entry(&self, req: &Credential) -> Result<(), CredentialError> {
+        self.handle.delete_entry(req).await
+    }
+
+    async fn path(&self) -> Bytes {
+        self.handle.path().await
+    }
+}
+
+/// An arbitrary directory level for credentials.
+///
+/// This corresponds to a given hierarchy within a vault.  For example, one might have multiple
+/// levels of directories in a vault in the system keychain manager, and each of those would be
+/// implemented as an struct implementing `CredentialDirectory`.
+pub struct CredentialDirectory {
+    handle: CredentialDirectoryHandle,
+}
+
+impl CredentialDirectory {
+    #[allow(dead_code)]
+    async fn get_id(&mut self) -> Result<StoreSelectorID, CredentialError> {
+        self.handle.get_id_mut().await
+    }
+
+    /// List the credential stores that are available.
+    #[allow(dead_code)]
+    pub async fn list_directories(&self) -> Result<Vec<CredentialDirectory>, CredentialError> {
+        self.handle.list_directories().await
+    }
+
+    #[allow(dead_code)]
+    pub async fn create_directory(
+        &self,
+        name: &[u8],
+    ) -> Result<CredentialDirectory, CredentialError> {
+        let handle = self.handle.create_directory(name).await?;
+        Ok(CredentialDirectory { handle })
+    }
+}
+
+#[async_trait]
+impl CredentialHandle for CredentialDirectory {
+    async fn authenticate(
+        &mut self,
+        last_id: Option<u32>,
+        method: &[u8],
+        message: Option<Bytes>,
+    ) -> Result<(Option<u32>, Option<Bytes>), CredentialError> {
+        self.handle.authenticate(last_id, method, message).await
+    }
+
+    async fn list_entries<'a>(
+        &'a self,
+    ) -> Result<Box<dyn Iterator<Item = StoreElement> + 'a>, CredentialError> {
+        self.handle.list_entries().await
+    }
+
+    async fn search_entry(
+        &self,
+        req: &CredentialRequest,
+        recurse: StoreSearchRecursionLevel,
+    ) -> Result<Option<Credential>, CredentialError> {
+        self.handle.search_entry(req, recurse).await
+    }
+
+    async fn get_entry(&self, component: &[u8]) -> Result<Option<Credential>, CredentialError> {
+        self.handle.get_entry(component).await
+    }
+
+    async fn create_entry(&self, req: &Credential) -> Result<(), CredentialError> {
+        self.handle.create_entry(req).await
+    }
+
+    async fn update_entry(&self, req: &Credential) -> Result<(), CredentialError> {
+        self.handle.update_entry(req).await
+    }
+
+    async fn put_entry(&self, req: &Credential) -> Result<(), CredentialError> {
+        self.handle.put_entry(req).await
+    }
+
+    async fn delete_entry(&self, req: &Credential) -> Result<(), CredentialError> {
+        self.handle.delete_entry(req).await
+    }
+
+    async fn path(&self) -> Bytes {
+        self.handle.path().await
+    }
+}
+
+/// A storage location for credentials.
+///
+/// This corresponds to a given vault type.  For example, one might have multiple keychains in the
+/// system keychain manager, and each of those would be implemented as an struct implementing
+/// `CredentialVault`.
+#[derive(Debug)]
+pub struct CredentialVault {
+    handle: CredentialDirectoryHandle,
+}
+
+impl CredentialVault {
+    #[allow(dead_code)]
+    async fn get_id(&mut self) -> Result<StoreSelectorID, CredentialError> {
+        self.handle.get_id_mut().await
+    }
+
+    /// List the credential stores that are available.
+    #[allow(dead_code)]
+    pub async fn list_directories(&self) -> Result<Vec<CredentialDirectory>, CredentialError> {
+        self.handle.list_directories().await
+    }
+
+    #[allow(dead_code)]
+    pub async fn create_directory(
+        &self,
+        name: &[u8],
+    ) -> Result<CredentialDirectory, CredentialError> {
+        let handle = self.handle.create_directory(name).await?;
+        Ok(CredentialDirectory { handle })
+    }
+}
+
+#[async_trait]
+impl CredentialHandle for CredentialVault {
+    async fn authenticate(
+        &mut self,
+        last_id: Option<u32>,
+        method: &[u8],
+        message: Option<Bytes>,
+    ) -> Result<(Option<u32>, Option<Bytes>), CredentialError> {
+        self.handle.authenticate(last_id, method, message).await
+    }
+
+    async fn list_entries<'a>(
+        &'a self,
+    ) -> Result<Box<dyn Iterator<Item = StoreElement> + 'a>, CredentialError> {
+        self.handle.list_entries().await
+    }
+
+    async fn search_entry(
+        &self,
+        req: &CredentialRequest,
+        recurse: StoreSearchRecursionLevel,
+    ) -> Result<Option<Credential>, CredentialError> {
+        self.handle.search_entry(req, recurse).await
+    }
+
+    async fn get_entry(&self, component: &[u8]) -> Result<Option<Credential>, CredentialError> {
+        self.handle.get_entry(component).await
+    }
+
+    async fn create_entry(&self, req: &Credential) -> Result<(), CredentialError> {
+        self.handle.create_entry(req).await
+    }
+
+    async fn update_entry(&self, req: &Credential) -> Result<(), CredentialError> {
+        self.handle.update_entry(req).await
+    }
+
+    async fn put_entry(&self, req: &Credential) -> Result<(), CredentialError> {
+        self.handle.put_entry(req).await
+    }
+
+    async fn delete_entry(&self, req: &Credential) -> Result<(), CredentialError> {
+        self.handle.delete_entry(req).await
+    }
+
+    async fn path(&self) -> Bytes {
+        self.handle.path().await
+    }
+}
+
+#[async_trait]
+pub trait CredentialHandle {
+    async fn authenticate(
+        &mut self,
+        last_id: Option<u32>,
+        method: &[u8],
+        message: Option<Bytes>,
+    ) -> Result<(Option<u32>, Option<Bytes>), CredentialError>;
+    async fn list_entries<'a>(
+        &'a self,
+    ) -> Result<Box<dyn Iterator<Item = StoreElement> + 'a>, CredentialError>;
+    async fn search_entry(
+        &self,
+        req: &CredentialRequest,
+        recurse: StoreSearchRecursionLevel,
+    ) -> Result<Option<Credential>, CredentialError>;
+    async fn get_entry(&self, component: &[u8]) -> Result<Option<Credential>, CredentialError>;
+    async fn put_entry(&self, req: &Credential) -> Result<(), CredentialError>;
+    async fn create_entry(&self, req: &Credential) -> Result<(), CredentialError>;
+    async fn update_entry(&self, req: &Credential) -> Result<(), CredentialError>;
+    async fn delete_entry(&self, req: &Credential) -> Result<(), CredentialError>;
+    async fn path(&self) -> Bytes;
+}
+
+pub trait CredentialSet {}
+
+// This value is serialized in some of the backends.  If you change it incompatibly, be sure to
+// separate that usage out into a separate struct.
+#[derive(Serialize, Deserialize, Default, Clone, Eq, PartialEq, Ord, PartialOrd, Debug)]
+pub struct Location {
+    pub(crate) protocol: Option<String>,
+    pub(crate) host: Option<String>,
+    pub(crate) port: Option<u16>,
+    pub(crate) path: Option<String>,
+}
+
+impl Location {
+    pub fn new() -> Self {
+        Default::default()
+    }
+
+    pub fn has_contents(&self) -> bool {
+        self.protocol.is_some() || self.host.is_some() || self.path.is_some()
+    }
+
+    pub fn protocol(&self) -> Option<&str> {
+        self.protocol.as_deref()
+    }
+
+    pub fn host(&self) -> Option<&str> {
+        self.host.as_deref()
+    }
+
+    pub fn port(&self) -> Option<u16> {
+        self.port
+    }
+
+    pub fn path(&self) -> Option<&str> {
+        self.path.as_deref()
+    }
+
+    pub fn as_url(&self) -> Option<String> {
+        // TODO: handle IPv6 addresses as hostnames.
+        let mut s = format!(
+            "{}://{}",
+            self.protocol.as_deref()?,
+            self.host.as_deref().unwrap_or_default()
+        );
+        if let Some(port) = self.port {
+            s += &format!(":{}", port);
+        }
+        match &self.path {
+            Some(path) if path.starts_with('/') => s += path,
+            Some(path) => s += &format!("/{}", path),
+            None => s += "/",
+        };
+        Some(s)
+    }
+}
+
+impl From<url::Url> for Location {
+    fn from(url: url::Url) -> Location {
+        Location::from(&url)
+    }
+}
+
+impl<'a> From<&'a url::Url> for Location {
+    fn from(url: &'a url::Url) -> Location {
+        Location {
+            protocol: Some(url.scheme().into()),
+            host: url.host_str().map(|host| host.into()),
+            path: Some(url.path().into()),
+            port: url.port(),
+        }
+    }
+}
+
+impl From<CredentialStoreLocation> for Location {
+    fn from(cse: CredentialStoreLocation) -> Location {
+        Location {
+            protocol: cse.protocol,
+            host: cse.host,
+            port: cse.port,
+            path: cse.path,
+        }
+    }
+}
+
+impl<'a> From<&'a CredentialStoreLocation> for Location {
+    fn from(cse: &'a CredentialStoreLocation) -> Location {
+        Location {
+            protocol: cse.protocol.clone(),
+            host: cse.host.clone(),
+            port: cse.port,
+            path: cse.path.clone(),
+        }
+    }
+}
+
+impl<'a> From<&'a mut CredentialStoreLocation> for Location {
+    fn from(cse: &'a mut CredentialStoreLocation) -> Location {
+        Location::from(cse as &CredentialStoreLocation)
+    }
+}
+
+impl From<Location> for CredentialStoreLocation {
+    fn from(cse: Location) -> CredentialStoreLocation {
+        CredentialStoreLocation {
+            protocol: cse.protocol,
+            host: cse.host,
+            port: cse.port,
+            path: cse.path,
+        }
+    }
+}
+
+impl<'a> From<&'a Location> for CredentialStoreLocation {
+    fn from(cse: &'a Location) -> CredentialStoreLocation {
+        CredentialStoreLocation {
+            protocol: cse.protocol.clone(),
+            host: cse.host.clone(),
+            port: cse.port,
+            path: cse.path.clone(),
+        }
+    }
+}
+
+impl<'a> From<&'a mut Location> for CredentialStoreLocation {
+    fn from(cse: &'a mut Location) -> CredentialStoreLocation {
+        CredentialStoreLocation::from(cse as &Location)
+    }
+}
+
+// This value is serialized in some of the backends.  If you change it incompatibly, be sure to
+// separate that usage out into a separate struct.
+#[derive(Serialize, Deserialize, Clone, Eq, PartialEq, Ord, PartialOrd, Debug)]
+#[serde(rename_all = "kebab-case")]
+pub struct Credential {
+    pub(crate) username: Option<Bytes>,
+    pub(crate) secret: Bytes,
+    pub(crate) authtype: Option<String>,
+    #[serde(rename = "type")]
+    pub(crate) kind: String,
+    pub(crate) title: Option<String>,
+    pub(crate) description: Option<String>,
+    pub(crate) location: Vec<Location>,
+    pub(crate) service: Option<String>,
+    pub(crate) extra: BTreeMap<String, Value>,
+    #[serde(skip)]
+    pub(crate) id: Bytes,
+}
+
+impl Default for Credential {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Credential {
+    pub fn new() -> Self {
+        Self {
+            username: None,
+            secret: Bytes::new(),
+            authtype: None,
+            title: None,
+            kind: String::new(),
+            description: None,
+            location: Vec::new(),
+            service: None,
+            extra: BTreeMap::new(),
+            id: Bytes::new(),
+        }
+    }
+
+    pub fn username(&self) -> Option<Bytes> {
+        self.username.clone()
+    }
+
+    pub fn secret(&self) -> Bytes {
+        self.secret.clone()
+    }
+
+    pub fn generate_id(&self) -> Bytes {
+        let mut digest = blake2::Blake2b512::new();
+        digest.update("lawn:credential:id:v1:");
+        digest.update(serde_cbor::to_vec(self).unwrap());
+        hex::encode(digest.finalize()).into()
+    }
+
+    pub fn title(&self) -> Option<&str> {
+        self.title.as_deref()
+    }
+
+    pub fn description(&self) -> Option<&str> {
+        self.description.as_deref()
+    }
+
+    pub fn id(&self) -> Bytes {
+        self.id.clone()
+    }
+
+    pub fn authtype(&self) -> Option<&str> {
+        self.authtype.as_deref()
+    }
+
+    pub fn location(&self) -> &[Location] {
+        &self.location
+    }
+
+    pub fn service(&self) -> Option<&str> {
+        self.service.as_deref()
+    }
+
+    pub fn extra(&self) -> &BTreeMap<String, Value> {
+        &self.extra
+    }
+
+    fn byte_request(req: Option<Bytes>) -> FieldRequest {
+        match req {
+            Some(r) => FieldRequest::LiteralBytes(r),
+            None => FieldRequest::Any,
+        }
+    }
+
+    fn str_request(req: Option<&str>) -> FieldRequest {
+        match req {
+            Some(r) => FieldRequest::LiteralString(r.into()),
+            None => FieldRequest::Any,
+        }
+    }
+
+    pub fn to_request(&self) -> CredentialRequest {
+        CredentialRequest {
+            username: Self::byte_request(self.username.clone()),
+            authtype: Self::str_request(self.authtype.as_deref()),
+            kind: Self::str_request(Some(&self.kind)),
+            protocol: Self::str_request(
+                self.location
+                    .first()
+                    .and_then(|loc| loc.protocol.as_deref()),
+            ),
+            host: Self::str_request(self.location.first().and_then(|loc| loc.host.as_deref())),
+            path: Self::str_request(self.location.first().and_then(|loc| loc.path.as_deref())),
+            id: Self::byte_request(Some(self.id.clone())),
+            title: Self::str_request(self.title.as_deref()),
+            description: Self::str_request(self.description.as_deref()),
+            service: Self::str_request(self.service.as_deref()),
+            extra: BTreeMap::new(),
+        }
+    }
+}
+
+impl TryFrom<CredentialStoreElement> for Credential {
+    type Error = MissingElementError<CredentialStoreElement>;
+    fn try_from(cse: CredentialStoreElement) -> Result<Credential, Self::Error> {
+        let secret = match cse.secret {
+            Some(secret) => secret,
+            None => return Err(MissingElementError::new("secret", cse)),
+        };
+        Ok(Credential {
+            username: cse.username,
+            secret,
+            authtype: cse.authtype,
+            kind: cse.kind,
+            title: cse.title,
+            description: cse.description,
+            location: cse.location.iter().map(|loc| loc.into()).collect(),
+            service: cse.service,
+            extra: cse.extra,
+            id: cse.id,
+        })
+    }
+}
+
+impl<'a> TryFrom<&'a CredentialStoreElement> for Credential {
+    type Error = MissingElementError<&'a CredentialStoreElement>;
+    fn try_from(cse: &'a CredentialStoreElement) -> Result<Credential, Self::Error> {
+        let secret = match cse.secret {
+            Some(ref secret) => secret.clone(),
+            None => return Err(MissingElementError::new("secret", cse)),
+        };
+        Ok(Credential {
+            username: cse.username.clone(),
+            secret,
+            authtype: cse.authtype.clone(),
+            kind: cse.kind.clone(),
+            title: cse.title.clone(),
+            description: cse.description.clone(),
+            location: cse.location.iter().map(|loc| loc.into()).collect(),
+            service: cse.service.clone(),
+            extra: cse.extra.clone(),
+            id: cse.id.clone(),
+        })
+    }
+}
+
+impl<'a> TryFrom<&'a mut CredentialStoreElement> for Credential {
+    type Error = MissingElementError<&'a mut CredentialStoreElement>;
+    fn try_from(cse: &'a mut CredentialStoreElement) -> Result<Credential, Self::Error> {
+        match Credential::try_from(cse as &CredentialStoreElement) {
+            Ok(r) => Ok(r),
+            Err(_) => Err(MissingElementError::new("secret", cse)),
+        }
+    }
+}
+
+impl From<Credential> for CredentialStoreElement {
+    fn from(cse: Credential) -> CredentialStoreElement {
+        CredentialStoreElement {
+            username: cse.username,
+            secret: Some(cse.secret),
+            authtype: cse.authtype,
+            kind: cse.kind,
+            title: cse.title,
+            description: cse.description,
+            location: cse.location.iter().map(|loc| loc.into()).collect(),
+            service: cse.service,
+            extra: cse.extra,
+            id: cse.id,
+        }
+    }
+}
+
+impl<'a> From<&'a Credential> for CredentialStoreElement {
+    fn from(cse: &'a Credential) -> CredentialStoreElement {
+        CredentialStoreElement {
+            username: cse.username.clone(),
+            secret: Some(cse.secret.clone()),
+            authtype: cse.authtype.clone(),
+            kind: cse.kind.clone(),
+            title: cse.title.clone(),
+            description: cse.description.clone(),
+            location: cse.location.iter().map(|loc| loc.into()).collect(),
+            service: cse.service.clone(),
+            extra: cse.extra.clone(),
+            id: cse.id.clone(),
+        }
+    }
+}
+
+impl<'a> From<&'a mut Credential> for CredentialStoreElement {
+    fn from(cse: &'a mut Credential) -> CredentialStoreElement {
+        CredentialStoreElement::from(cse as &Credential)
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum CredentialParserError {
+    #[error("invalid serialization: {0}")]
+    InvalidSerialization(Cow<'static, str>),
+    #[error("unsatisfiable request {1} for field {0}")]
+    UnsatisfiableRequest(Cow<'static, str>, Cow<'static, str>),
+    #[error("i/o error: {0}")]
+    IOError(#[from] io::Error),
+    #[error("no such handle")]
+    NoSuchHandle,
+    #[error("spawn error")]
+    SpawnError,
+    #[error("unauthenticated")]
+    Unauthenticated,
+    #[error("protocol message too large")]
+    DataTooLarge,
+    #[error("unlistable")]
+    Unlistable,
+}
+
+#[cfg(test)]
+impl Clone for CredentialParserError {
+    fn clone(&self) -> Self {
+        match self {
+            CredentialParserError::IOError(e) => match e.raw_os_error() {
+                Some(e) => CredentialParserError::IOError(io::Error::from_raw_os_error(e)),
+                None => CredentialParserError::IOError(io::Error::new(e.kind(), format!("{}", e))),
+            },
+            x => x.clone(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Hash, Eq, PartialEq, Ord, PartialOrd)]
+pub enum FieldRequest {
+    LiteralBytes(Bytes),
+    LiteralString(String),
+    Set(BTreeSet<FieldRequest>),
+    Sequence(Vec<FieldRequest>),
+    Any,
+    None,
+}
+
+impl Default for FieldRequest {
+    fn default() -> Self {
+        FieldRequest::Any
+    }
+}
+
+impl FieldRequest {
+    fn matches_bytes(&self, v: Option<&Bytes>) -> bool {
+        match (self, v) {
+            (FieldRequest::LiteralBytes(b), Some(v)) => b == v,
+            (FieldRequest::LiteralBytes(_), _) => false,
+            (FieldRequest::LiteralString(s), Some(v)) => s.as_bytes() == v,
+            (FieldRequest::LiteralString(_), _) => false,
+            (FieldRequest::Set(s), v) => s.iter().any(|req| req.matches_bytes(v)),
+            (FieldRequest::Sequence(s), v) => s.iter().any(|req| req.matches_bytes(v)),
+            (FieldRequest::Any, _) => true,
+            (FieldRequest::None, v) => v.is_none(),
+        }
+    }
+
+    fn matches_string(&self, v: Option<&str>) -> bool {
+        match (self, v) {
+            (FieldRequest::LiteralString(s), Some(v)) => s == v,
+            (FieldRequest::LiteralString(_), _) => false,
+            (FieldRequest::LiteralBytes(b), Some(v)) => b == v.as_bytes(),
+            (FieldRequest::LiteralBytes(_), _) => false,
+            (FieldRequest::Set(s), v) => s.iter().any(|req| req.matches_string(v)),
+            (FieldRequest::Sequence(s), v) => s.iter().any(|req| req.matches_string(v)),
+            (FieldRequest::Any, _) => true,
+            (FieldRequest::None, v) => v.is_none(),
+        }
+    }
+
+    fn matches_value(&self, v: &Value) -> bool {
+        match (self, v) {
+            (FieldRequest::LiteralString(s), Value::Text(v)) => s == v,
+            (FieldRequest::LiteralString(s), Value::Bytes(v)) => s.as_bytes() == *v,
+            (FieldRequest::LiteralString(_), _) => false,
+            (FieldRequest::LiteralBytes(b), Value::Bytes(v)) => b == v,
+            (FieldRequest::LiteralBytes(b), Value::Text(v)) => b == v.as_bytes(),
+            (FieldRequest::LiteralBytes(_), _) => false,
+            (FieldRequest::Set(s), v) => s.iter().any(|req| req.matches_value(v)),
+            (FieldRequest::Sequence(s), v) => s.iter().any(|req| req.matches_value(v)),
+            (FieldRequest::Any, _) => true,
+            (FieldRequest::None, Value::Null) => true,
+            (FieldRequest::None, _) => false,
+        }
+    }
+}
+
+#[derive(Default)]
+pub struct UnsupportedSerialization<T>(T);
+
+impl TryFrom<SearchStoreElementType> for FieldRequest {
+    type Error = UnsupportedSerialization<SearchStoreElementType>;
+
+    fn try_from(sset: SearchStoreElementType) -> Result<FieldRequest, Self::Error> {
+        match sset {
+            SearchStoreElementType::Literal(Value::Text(s)) => Ok(FieldRequest::LiteralString(s)),
+            SearchStoreElementType::Literal(Value::Bytes(b)) => {
+                Ok(FieldRequest::LiteralBytes(b.into()))
+            }
+            SearchStoreElementType::Literal(_) => Err(UnsupportedSerialization(sset)),
+            SearchStoreElementType::Set(ref s) => match s
+                .iter()
+                .map(FieldRequest::try_from)
+                .collect::<Result<_, _>>()
+            {
+                Ok(s) => Ok(FieldRequest::Set(s)),
+                Err(_) => Err(UnsupportedSerialization(sset)),
+            },
+            SearchStoreElementType::Sequence(ref s) => match s
+                .iter()
+                .map(FieldRequest::try_from)
+                .collect::<Result<_, _>>()
+            {
+                Ok(s) => Ok(FieldRequest::Sequence(s)),
+                Err(_) => Err(UnsupportedSerialization(sset)),
+            },
+            SearchStoreElementType::Any(_) => Ok(FieldRequest::Any),
+            SearchStoreElementType::None(_) => Ok(FieldRequest::None),
+        }
+    }
+}
+
+impl<'a> TryFrom<&'a SearchStoreElementType> for FieldRequest {
+    type Error = UnsupportedSerialization<&'a SearchStoreElementType>;
+
+    fn try_from(sset: &'a SearchStoreElementType) -> Result<FieldRequest, Self::Error> {
+        match sset {
+            SearchStoreElementType::Literal(Value::Text(s)) => {
+                Ok(FieldRequest::LiteralString(s.clone()))
+            }
+            SearchStoreElementType::Literal(Value::Bytes(b)) => {
+                Ok(FieldRequest::LiteralBytes(b.clone().into()))
+            }
+            SearchStoreElementType::Literal(_) => Err(UnsupportedSerialization(sset)),
+            SearchStoreElementType::Set(s) => match s
+                .iter()
+                .map(FieldRequest::try_from)
+                .collect::<Result<_, _>>()
+            {
+                Ok(s) => Ok(FieldRequest::Set(s)),
+                Err(_) => Err(UnsupportedSerialization(sset)),
+            },
+            SearchStoreElementType::Sequence(s) => match s
+                .iter()
+                .map(FieldRequest::try_from)
+                .collect::<Result<_, _>>()
+            {
+                Ok(s) => Ok(FieldRequest::Sequence(s)),
+                Err(_) => Err(UnsupportedSerialization(sset)),
+            },
+            SearchStoreElementType::Any(_) => Ok(FieldRequest::Any),
+            SearchStoreElementType::None(_) => Ok(FieldRequest::None),
+        }
+    }
+}
+
+impl<'a> TryFrom<&'a mut SearchStoreElementType> for FieldRequest {
+    type Error = UnsupportedSerialization<&'a mut SearchStoreElementType>;
+
+    fn try_from(sset: &'a mut SearchStoreElementType) -> Result<FieldRequest, Self::Error> {
+        match sset {
+            SearchStoreElementType::Literal(Value::Text(s)) => {
+                Ok(FieldRequest::LiteralString(s.clone()))
+            }
+            SearchStoreElementType::Literal(Value::Bytes(b)) => {
+                Ok(FieldRequest::LiteralBytes(b.clone().into()))
+            }
+            SearchStoreElementType::Literal(_) => Err(UnsupportedSerialization(sset)),
+            SearchStoreElementType::Set(s) => match s
+                .iter()
+                .map(FieldRequest::try_from)
+                .collect::<Result<_, _>>()
+            {
+                Ok(s) => Ok(FieldRequest::Set(s)),
+                Err(_) => Err(UnsupportedSerialization(sset)),
+            },
+            SearchStoreElementType::Sequence(s) => match s
+                .iter()
+                .map(FieldRequest::try_from)
+                .collect::<Result<_, _>>()
+            {
+                Ok(s) => Ok(FieldRequest::Sequence(s)),
+                Err(_) => Err(UnsupportedSerialization(sset)),
+            },
+            SearchStoreElementType::Any(_) => Ok(FieldRequest::Any),
+            SearchStoreElementType::None(_) => Ok(FieldRequest::None),
+        }
+    }
+}
+
+impl From<FieldRequest> for SearchStoreElementType {
+    fn from(fr: FieldRequest) -> Self {
+        match fr {
+            FieldRequest::LiteralBytes(b) => {
+                SearchStoreElementType::Literal(Value::Bytes(b.into()))
+            }
+            FieldRequest::LiteralString(s) => SearchStoreElementType::Literal(Value::Text(s)),
+            FieldRequest::Set(s) => {
+                SearchStoreElementType::Set(s.iter().map(SearchStoreElementType::from).collect())
+            }
+            FieldRequest::Sequence(s) => SearchStoreElementType::Sequence(
+                s.iter().map(SearchStoreElementType::from).collect(),
+            ),
+            FieldRequest::Any => SearchStoreElementType::Any(()),
+            FieldRequest::None => SearchStoreElementType::None(()),
+        }
+    }
+}
+
+impl<'a> From<&'a FieldRequest> for SearchStoreElementType {
+    fn from(fr: &'a FieldRequest) -> Self {
+        match fr {
+            FieldRequest::LiteralBytes(b) => {
+                SearchStoreElementType::Literal(Value::Bytes(b.clone().into()))
+            }
+            FieldRequest::LiteralString(s) => {
+                SearchStoreElementType::Literal(Value::Text(s.clone()))
+            }
+            FieldRequest::Set(s) => {
+                SearchStoreElementType::Set(s.iter().map(SearchStoreElementType::from).collect())
+            }
+            FieldRequest::Sequence(s) => SearchStoreElementType::Sequence(
+                s.iter().map(SearchStoreElementType::from).collect(),
+            ),
+            FieldRequest::Any => SearchStoreElementType::Any(()),
+            FieldRequest::None => SearchStoreElementType::None(()),
+        }
+    }
+}
+
+impl<'a> From<&'a mut FieldRequest> for SearchStoreElementType {
+    fn from(fr: &'a mut FieldRequest) -> Self {
+        match fr {
+            FieldRequest::LiteralBytes(b) => {
+                SearchStoreElementType::Literal(Value::Bytes(b.clone().into()))
+            }
+            FieldRequest::LiteralString(s) => {
+                SearchStoreElementType::Literal(Value::Text(s.clone()))
+            }
+            FieldRequest::Set(s) => {
+                SearchStoreElementType::Set(s.iter().map(SearchStoreElementType::from).collect())
+            }
+            FieldRequest::Sequence(s) => SearchStoreElementType::Sequence(
+                s.iter().map(SearchStoreElementType::from).collect(),
+            ),
+            FieldRequest::Any => SearchStoreElementType::Any(()),
+            FieldRequest::None => SearchStoreElementType::None(()),
+        }
+    }
+}
+
+#[derive(Default, Debug, Clone)]
+pub struct CredentialRequest {
+    pub(crate) username: FieldRequest,
+    pub(crate) authtype: FieldRequest,
+    pub(crate) protocol: FieldRequest,
+    pub(crate) kind: FieldRequest,
+    pub(crate) host: FieldRequest,
+    pub(crate) title: FieldRequest,
+    pub(crate) description: FieldRequest,
+    pub(crate) path: FieldRequest,
+    pub(crate) service: FieldRequest,
+    pub(crate) id: FieldRequest,
+    pub(crate) extra: BTreeMap<String, FieldRequest>,
+}
+
+impl CredentialRequest {
+    pub fn new() -> Self {
+        Self {
+            username: FieldRequest::Any,
+            authtype: FieldRequest::Any,
+            protocol: FieldRequest::Any,
+            title: FieldRequest::Any,
+            kind: FieldRequest::Any,
+            description: FieldRequest::Any,
+            host: FieldRequest::Any,
+            path: FieldRequest::Any,
+            service: FieldRequest::Any,
+            id: FieldRequest::Any,
+            extra: BTreeMap::new(),
+        }
+    }
+
+    pub fn matches(&self, cred: &Credential) -> bool {
+        self.username.matches_bytes(cred.username.as_ref()) &&
+        self.authtype.matches_string(cred.authtype.as_deref()) &&
+        self.kind.matches_string(Some(&cred.kind)) &&
+        // TODO: match Any and None with no location
+        cred.location.iter().any(|loc|
+        self.protocol.matches_string(loc.protocol.as_deref()) &&
+        self.host.matches_string(loc.host.as_deref()) &&
+        self.path.matches_string(loc.path.as_deref())) &&
+        self.service.matches_string(cred.service.as_deref()) &&
+        self.title.matches_string(cred.title.as_deref()) &&
+        self.description.matches_string(cred.description.as_deref()) &&
+        self.id.matches_string(cred.service.as_deref()) &&
+        self.extra.iter().all(|(k, v)| {
+            let val = cred.extra.get(k).unwrap_or(&Value::Null);
+            v.matches_value(val)
+        })
+    }
+}
+
+impl<'a> From<&'a mut CredentialRequest> for CredentialStoreSearchElement {
+    fn from(cr: &'a mut CredentialRequest) -> Self {
+        Self::from(cr as &'a CredentialRequest)
+    }
+}
+
+impl<'a> From<&'a CredentialRequest> for CredentialStoreSearchElement {
+    fn from(cr: &'a CredentialRequest) -> Self {
+        CredentialStoreSearchElement {
+            username: (&cr.username).into(),
+            secret: SearchStoreElementType::Any(()),
+            authtype: (&cr.authtype).into(),
+            kind: (&cr.kind).into(),
+            protocol: (&cr.protocol).into(),
+            host: (&cr.host).into(),
+            path: (&cr.path).into(),
+            title: (&cr.title).into(),
+            description: (&cr.description).into(),
+            service: (&cr.service).into(),
+            id: (&cr.id).into(),
+            extra: cr
+                .extra
+                .iter()
+                .map(|(k, v)| (k.clone(), (*v).clone().into()))
+                .collect(),
+        }
+    }
+}
+
+impl From<CredentialRequest> for CredentialStoreSearchElement {
+    fn from(cr: CredentialRequest) -> Self {
+        Self::from(&cr)
+    }
+}
+
+impl TryFrom<CredentialStoreSearchElement> for CredentialRequest {
+    type Error = UnsupportedSerialization<CredentialStoreSearchElement>;
+
+    fn try_from(csse: CredentialStoreSearchElement) -> Result<Self, Self::Error> {
+        let f = |csse: &CredentialStoreSearchElement| {
+            Some(CredentialRequest {
+                username: (&csse.username).try_into().ok()?,
+                authtype: (&csse.authtype).try_into().ok()?,
+                kind: (&csse.kind).try_into().ok()?,
+                protocol: (&csse.protocol).try_into().ok()?,
+                host: (&csse.host).try_into().ok()?,
+                path: (&csse.path).try_into().ok()?,
+                title: (&csse.title).try_into().ok()?,
+                description: (&csse.description).try_into().ok()?,
+                service: (&csse.service).try_into().ok()?,
+                id: (&csse.id).try_into().ok()?,
+                extra: csse
+                    .extra
+                    .iter()
+                    .map(|(k, v)| {
+                        Ok::<_, UnsupportedSerialization<_>>((k.clone(), (*v).clone().try_into()?))
+                    })
+                    .collect::<Result<_, _>>()
+                    .ok()?,
+            })
+        };
+        match f(&csse) {
+            Some(cr) => Ok(cr),
+            None => Err(UnsupportedSerialization(csse)),
+        }
+    }
+}
+
+impl<'a> TryFrom<&'a CredentialStoreSearchElement> for CredentialRequest {
+    type Error = UnsupportedSerialization<&'a CredentialStoreSearchElement>;
+
+    fn try_from(csse: &'a CredentialStoreSearchElement) -> Result<Self, Self::Error> {
+        let f = |csse: &CredentialStoreSearchElement| {
+            Some(CredentialRequest {
+                username: (&csse.username).try_into().ok()?,
+                authtype: (&csse.authtype).try_into().ok()?,
+                kind: (&csse.kind).try_into().ok()?,
+                protocol: (&csse.protocol).try_into().ok()?,
+                host: (&csse.host).try_into().ok()?,
+                title: (&csse.title).try_into().ok()?,
+                description: (&csse.description).try_into().ok()?,
+                path: (&csse.path).try_into().ok()?,
+                service: (&csse.service).try_into().ok()?,
+                id: (&csse.id).try_into().ok()?,
+                extra: csse
+                    .extra
+                    .iter()
+                    .map(|(k, v)| {
+                        Ok::<_, UnsupportedSerialization<_>>((k.clone(), (*v).clone().try_into()?))
+                    })
+                    .collect::<Result<_, _>>()
+                    .ok()?,
+            })
+        };
+        match f(&csse) {
+            Some(cr) => Ok(cr),
+            None => Err(UnsupportedSerialization(csse)),
+        }
+    }
+}
+
+impl<'a> TryFrom<&'a mut CredentialStoreSearchElement> for CredentialRequest {
+    type Error = UnsupportedSerialization<&'a mut CredentialStoreSearchElement>;
+
+    fn try_from(csse: &'a mut CredentialStoreSearchElement) -> Result<Self, Self::Error> {
+        match CredentialRequest::try_from(csse as &CredentialStoreSearchElement) {
+            Ok(cr) => Ok(cr),
+            Err(_) => Err(UnsupportedSerialization(csse)),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Location;
+
+    #[test]
+    fn formats_locations_as_url() {
+        let cases = &[
+            (
+                Some("https"),
+                Some("example.com"),
+                None,
+                Some("/foo"),
+                Some("https://example.com/foo"),
+            ),
+            (
+                Some("https"),
+                Some("example.com"),
+                None,
+                Some("foo"),
+                Some("https://example.com/foo"),
+            ),
+            (
+                Some("https"),
+                Some("example.com"),
+                Some(3128),
+                Some("/foo"),
+                Some("https://example.com:3128/foo"),
+            ),
+            (
+                Some("https"),
+                Some("example.com"),
+                None,
+                None,
+                Some("https://example.com/"),
+            ),
+            (
+                Some("cert"),
+                None,
+                None,
+                Some("/dev/null"),
+                Some("cert:///dev/null"),
+            ),
+            (
+                Some("file"),
+                None,
+                None,
+                Some("/dev/null"),
+                Some("file:///dev/null"),
+            ),
+        ];
+
+        for (proto, hostname, port, path, result) in cases {
+            let loc = Location {
+                protocol: proto.map(ToOwned::to_owned),
+                host: hostname.map(ToOwned::to_owned),
+                port: *port,
+                path: path.map(ToOwned::to_owned),
+            };
+            assert_eq!(loc.as_url().as_deref(), *result);
+        }
+    }
+}

--- a/lawn/src/credential/protocol.rs
+++ b/lawn/src/credential/protocol.rs
@@ -1,0 +1,1 @@
+pub mod git;

--- a/lawn/src/credential/protocol/git.rs
+++ b/lawn/src/credential/protocol/git.rs
@@ -1,0 +1,597 @@
+use crate::credential::{
+    Credential, CredentialParserError, CredentialRequest, FieldRequest, Location,
+};
+use bytes::Bytes;
+use std::borrow::Cow;
+use std::collections::BTreeSet;
+use std::io::{self, Read, Write};
+use std::sync::{Arc, Mutex};
+
+#[derive(Debug, Hash, Eq, PartialEq, Ord, PartialOrd)]
+enum Extension {
+    AuthType,
+    Service,
+}
+
+type CredentialTitler = dyn (Fn(&Credential) -> Option<String>) + Send + Sync;
+type BoxedCredentialTitler = Box<CredentialTitler>;
+
+pub struct GitProtocolHandler {
+    rdr: Arc<Mutex<dyn Read + Send>>,
+    wrtr: Mutex<Option<Arc<Mutex<dyn Write + Send>>>>,
+    extensions: Mutex<BTreeSet<Extension>>,
+    service: Option<String>,
+    kind: String,
+    titler: BoxedCredentialTitler,
+}
+
+impl GitProtocolHandler {
+    const BUFFER_SIZE: usize = 1024 * 1024;
+
+    pub fn new(
+        rdr: Arc<Mutex<dyn Read + Send>>,
+        wrtr: Arc<Mutex<dyn Write + Send>>,
+        service: Option<&str>,
+        kind: Option<&str>,
+        titler: Option<BoxedCredentialTitler>,
+    ) -> Arc<Self> {
+        Arc::new(Self {
+            rdr,
+            wrtr: Mutex::new(Some(wrtr)),
+            extensions: Mutex::new(BTreeSet::new()),
+            service: service.map(ToOwned::to_owned),
+            kind: kind.unwrap_or("api").to_owned(),
+            titler: titler.unwrap_or_else(|| {
+                Box::new(|c: &Credential| {
+                    Some(format!(
+                        "Git: {}",
+                        c.location().first().and_then(|loc| loc.as_url())?
+                    ))
+                })
+            }),
+        })
+    }
+
+    pub fn close_writer(self: Arc<Self>) {
+        *self.wrtr.lock().unwrap() = None;
+    }
+
+    fn write_kv_request<T: Write>(
+        v: &mut io::BufWriter<T>,
+        key: &'static str,
+        fr: &FieldRequest,
+        multi: bool,
+    ) -> Result<(), CredentialParserError> {
+        match (fr, multi) {
+            (FieldRequest::LiteralBytes(b), _) => Self::write_kv(v, key, &b)?,
+            (FieldRequest::LiteralString(s), _) => Self::write_kv(v, key, s.as_bytes())?,
+            (FieldRequest::Set(s), true) => {
+                for item in s {
+                    Self::write_kv_request(v, key, &item, false)?;
+                }
+            }
+            (FieldRequest::Set(_), false) => {
+                return Err(CredentialParserError::UnsatisfiableRequest(
+                    key.into(),
+                    "set".into(),
+                ))
+            }
+            (FieldRequest::Sequence(s), true) => {
+                for item in s {
+                    Self::write_kv_request(v, key, &item, false)?;
+                }
+            }
+            (FieldRequest::Sequence(_), false) => {
+                return Err(CredentialParserError::UnsatisfiableRequest(
+                    key.into(),
+                    "sequence".into(),
+                ))
+            }
+            (FieldRequest::Any, _) | (FieldRequest::None, _) => (),
+        }
+        Ok(())
+    }
+
+    pub fn send_fill_request(
+        self: Arc<Self>,
+        req: &CredentialRequest,
+    ) -> Result<(), CredentialParserError> {
+        let wrtr = self.wrtr.lock().unwrap();
+        let wrtr = wrtr.as_ref().ok_or(CredentialParserError::NoSuchHandle)?;
+        let mut wrtr = wrtr.lock().unwrap();
+        let mut v = io::BufWriter::new(&mut *wrtr);
+        let extensions = self.extensions.lock().unwrap();
+        if extensions.contains(&Extension::AuthType) {
+            Self::write_kv(
+                &mut v,
+                "capability",
+                b"authtype@lawn.ns.crustytoothpaste.net",
+            )?;
+        }
+        if extensions.contains(&Extension::Service) {
+            Self::write_kv(
+                &mut v,
+                "capability",
+                b"service@lawn.ns.crustytoothpaste.net",
+            )?;
+        }
+        Self::write_kv_request(&mut v, "username", &req.username, false)?;
+        Self::write_kv_request(&mut v, "protocol", &req.protocol, false)?;
+        Self::write_kv_request(&mut v, "host", &req.host, false)?;
+        Self::write_kv_request(&mut v, "path", &req.path, false)?;
+        if extensions.contains(&Extension::AuthType) {
+            Self::write_kv_request(&mut v, "authtype", &req.authtype, false)?;
+        }
+        if extensions.contains(&Extension::Service) {
+            Self::write_kv_request(&mut v, "service", &req.service, false)?;
+        }
+        if let Some(wwwauth) = req.extra.get("wwwauth@git.ns.crustytoothpaste.net") {
+            Self::write_kv_request(&mut v, "wwwauth[]", &wwwauth, true)?;
+        }
+        Ok(())
+    }
+
+    #[allow(dead_code)]
+    pub fn parse_fill_request(self: Arc<Self>) -> Result<CredentialRequest, CredentialParserError> {
+        let buf = self.clone().read_buf_to_max()?;
+        let mut req = CredentialRequest::new();
+        for line in buf.split(|x| *x == b'\n') {
+            let mut pair = line.splitn(2, |x| *x == b'=');
+            match (pair.next(), pair.next()) {
+                (Some(b"protocol"), Some(val)) => {
+                    req.protocol = FieldRequest::LiteralBytes(Bytes::from(val.to_vec()))
+                }
+                (Some(b"host"), Some(val)) => {
+                    req.host = FieldRequest::LiteralBytes(Bytes::from(val.to_vec()))
+                }
+                (Some(b"path"), Some(val)) => {
+                    req.path = FieldRequest::LiteralBytes(Bytes::from(val.to_vec()))
+                }
+                (Some(b"username"), Some(val)) => {
+                    req.username = FieldRequest::LiteralBytes(Bytes::from(val.to_vec()))
+                }
+                (Some(b"wwwauth[]"), Some(val)) => {
+                    if let FieldRequest::Sequence(v) = req
+                        .extra
+                        .entry(String::from("wwwauth@git.ns.crustytoothpaste.net"))
+                        .or_insert_with(|| FieldRequest::Sequence(Vec::new()))
+                    {
+                        v.push(FieldRequest::LiteralBytes(Bytes::from(val.to_vec())));
+                    }
+                }
+                (Some(b"capability"), Some(b"authtype@lawn.ns.crustytoothpaste.net")) => {
+                    let mut extensions = self.extensions.lock().unwrap();
+                    extensions.insert(Extension::AuthType);
+                }
+                (Some(b"capability"), Some(b"service@lawn.ns.crustytoothpaste.net")) => {
+                    let mut extensions = self.extensions.lock().unwrap();
+                    extensions.insert(Extension::Service);
+                }
+                (Some(b"service"), Some(val)) => {
+                    let extensions = self.extensions.lock().unwrap();
+                    if extensions.contains(&Extension::Service) {
+                        req.service = FieldRequest::LiteralBytes(Bytes::from(val.to_vec()));
+                    }
+                }
+                (Some(b""), None) => (),
+                (Some(_), None) => {
+                    return Err(CredentialParserError::InvalidSerialization(Cow::Borrowed(
+                        "equals sign required",
+                    )))
+                }
+                _ => (),
+            }
+        }
+        Ok(req)
+    }
+
+    fn write_kv<T: Write>(v: &mut io::BufWriter<T>, key: &str, value: &[u8]) -> io::Result<()> {
+        v.write_all(key.as_bytes())?;
+        v.write_all(b"=")?;
+        v.write_all(value)?;
+        v.write_all(b"\n")?;
+        Ok(())
+    }
+
+    pub fn parse_fill_response(
+        self: Arc<Self>,
+    ) -> Result<Option<Credential>, CredentialParserError> {
+        self.parse_approve_reject_request(true)
+    }
+
+    pub fn send_fill_response(self: Arc<Self>, cred: Option<&Credential>) -> io::Result<()> {
+        let cred = match cred {
+            Some(c) => c,
+            None => return Ok(()),
+        };
+        let wrtr = self.wrtr.lock().unwrap();
+        let wrtr = wrtr
+            .as_ref()
+            .ok_or(io::Error::from_raw_os_error(libc::EBADF))?;
+        let mut wrtr = wrtr.lock().unwrap();
+        let mut v = io::BufWriter::new(&mut *wrtr);
+        let extensions = self.extensions.lock().unwrap();
+        if extensions.contains(&Extension::AuthType) {
+            Self::write_kv(
+                &mut v,
+                "capability",
+                b"authtype@lawn.ns.crustytoothpaste.net",
+            )?;
+        }
+        if extensions.contains(&Extension::Service) {
+            Self::write_kv(
+                &mut v,
+                "capability",
+                b"service@lawn.ns.crustytoothpaste.net",
+            )?;
+        }
+        if let Some(val) = &cred.username {
+            Self::write_kv(&mut v, "username", val)?;
+        }
+        Self::write_kv(&mut v, "password", &cred.secret)?;
+        if extensions.contains(&Extension::AuthType) {
+            if let Some(val) = &cred.authtype {
+                Self::write_kv(&mut v, "authtype", val.as_bytes())?;
+            }
+        }
+        if extensions.contains(&Extension::Service) {
+            if let Some(val) = &cred.service {
+                Self::write_kv(&mut v, "service", val.as_bytes())?;
+            }
+        }
+        if let Some(loc) = &cred.location.first() {
+            if let Some(val) = &loc.protocol {
+                Self::write_kv(&mut v, "protocol", val.as_bytes())?;
+            }
+            if let Some(val) = &loc.host {
+                Self::write_kv(&mut v, "host", val.as_bytes())?;
+            }
+            if let Some(val) = &loc.path {
+                Self::write_kv(&mut v, "path", val.as_bytes())?;
+            }
+        }
+        Self::write_kv(&mut v, "id", &cred.id)?;
+        Ok(())
+    }
+
+    pub fn parse_approve_reject_request(
+        self: Arc<Self>,
+        need_secret: bool,
+    ) -> Result<Option<Credential>, CredentialParserError> {
+        let buf = self.clone().read_buf_to_max()?;
+        let mut cred = Credential::new();
+        let mut loc = Location::new();
+        let mut has_secret = false;
+        let mut id = None;
+        for line in buf.split(|x| *x == b'\n') {
+            let mut pair = line.splitn(2, |x| *x == b'=');
+            match (pair.next(), pair.next()) {
+                (Some(b"protocol"), Some(val)) => {
+                    if let Ok(s) = std::str::from_utf8(val) {
+                        loc.protocol = Some(s.into());
+                    }
+                }
+                (Some(b"host"), Some(val)) => {
+                    if let Ok(s) = std::str::from_utf8(val) {
+                        loc.host = Some(s.into());
+                    }
+                }
+                (Some(b"path"), Some(val)) => {
+                    if let Ok(s) = std::str::from_utf8(val) {
+                        loc.path = Some(s.into());
+                    }
+                }
+                (Some(b"username"), Some(val)) => {
+                    cred.username = Some(Bytes::from(val.to_vec()));
+                }
+                (Some(b"password"), Some(val)) => {
+                    cred.secret = Bytes::from(val.to_vec());
+                    has_secret = true;
+                }
+                (Some(b"authtype"), Some(val)) => {
+                    if let Ok(s) = std::str::from_utf8(val) {
+                        cred.authtype = Some(s.into());
+                    }
+                }
+                (Some(b"id"), Some(val)) => {
+                    id = Some(Bytes::copy_from_slice(val));
+                }
+                (Some(b"capability"), Some(b"authtype@lawn.ns.crustytoothpaste.net")) => {
+                    let mut extensions = self.extensions.lock().unwrap();
+                    extensions.insert(Extension::AuthType);
+                }
+                (Some(b"capability"), Some(b"service@lawn.ns.crustytoothpaste.net")) => {
+                    let mut extensions = self.extensions.lock().unwrap();
+                    extensions.insert(Extension::Service);
+                }
+                (Some(b""), None) => (),
+                (Some(_), None) => {
+                    return Err(CredentialParserError::InvalidSerialization(Cow::Borrowed(
+                        "equals sign required",
+                    )))
+                }
+                _ => (),
+            }
+        }
+        if loc.has_contents() {
+            cred.location = vec![loc];
+        }
+        if cred.service.is_none() {
+            cred.service = self.service.clone();
+        }
+        cred.kind = self.kind.clone();
+        cred.title = (*self.titler)(&cred);
+        cred.id = id.unwrap_or_else(|| cred.generate_id());
+        if has_secret || !need_secret {
+            Ok(Some(cred))
+        } else {
+            Ok(None)
+        }
+    }
+
+    pub fn send_approve_reject_request(self: Arc<Self>, credential: &Credential) -> io::Result<()> {
+        self.send_fill_response(Some(credential))
+    }
+
+    fn read_buf_to_max(self: Arc<Self>) -> Result<Vec<u8>, CredentialParserError> {
+        let mut rdr = self.rdr.lock().unwrap();
+        let mut vec = vec![0u8; Self::BUFFER_SIZE];
+        let mut off = 0;
+        while off < vec.len() {
+            match rdr.read(&mut vec[off..]) {
+                Ok(0) => {
+                    vec.truncate(off);
+                    break;
+                }
+                Ok(n) => off += n,
+                Err(e) if e.kind() == io::ErrorKind::Interrupted => continue,
+                Err(e) => return Err(CredentialParserError::IOError(e)),
+            }
+        }
+        if off == Self::BUFFER_SIZE {
+            return Err(CredentialParserError::DataTooLarge);
+        }
+        Ok(vec)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Credential, CredentialRequest, FieldRequest, GitProtocolHandler, Location};
+    use bytes::Bytes;
+    use std::collections::BTreeMap;
+    use std::io::Cursor;
+    use std::sync::{Arc, Mutex};
+
+    #[test]
+    fn test_parse_fill_simple() {
+        let input = br"protocol=https
+host=example.com
+";
+        let rdr = Arc::new(Mutex::new(Cursor::new(input)));
+        let wrtr = Arc::new(Mutex::new(Cursor::new(Vec::new())));
+        let handler = GitProtocolHandler::new(rdr, wrtr, Some("git"), None, None);
+        let req = handler.parse_fill_request().unwrap();
+        assert_eq!(req.username, FieldRequest::Any);
+        assert_eq!(req.authtype, FieldRequest::Any);
+        assert_eq!(
+            req.protocol,
+            FieldRequest::LiteralBytes(Bytes::from(b"https" as &[u8]))
+        );
+        assert_eq!(
+            req.host,
+            FieldRequest::LiteralBytes(Bytes::from(b"example.com" as &[u8]))
+        );
+        assert_eq!(req.path, FieldRequest::Any);
+        assert_eq!(req.service, FieldRequest::Any);
+        assert!(req.extra.is_empty());
+    }
+
+    #[test]
+    fn test_parse_fill_complex() {
+        let input = br"protocol=https
+host=example.com
+username=cookie-monster
+path=/foo/bar/baz.git
+";
+        let rdr = Arc::new(Mutex::new(Cursor::new(input)));
+        let wrtr = Arc::new(Mutex::new(Cursor::new(Vec::new())));
+        let handler = GitProtocolHandler::new(rdr, wrtr, Some("git"), None, None);
+        let req = handler.parse_fill_request().unwrap();
+        assert_eq!(
+            req.username,
+            FieldRequest::LiteralBytes(Bytes::from(b"cookie-monster" as &[u8]))
+        );
+        assert_eq!(req.authtype, FieldRequest::Any);
+        assert_eq!(
+            req.protocol,
+            FieldRequest::LiteralBytes(Bytes::from(b"https" as &[u8]))
+        );
+        assert_eq!(
+            req.host,
+            FieldRequest::LiteralBytes(Bytes::from(b"example.com" as &[u8]))
+        );
+        assert_eq!(
+            req.path,
+            FieldRequest::LiteralBytes(Bytes::from(b"/foo/bar/baz.git" as &[u8]))
+        );
+        assert_eq!(req.service, FieldRequest::Any);
+        assert!(req.extra.is_empty());
+    }
+
+    #[test]
+    fn test_parse_fill_extensions() {
+        let input = br#"capability=authtype@lawn.ns.crustytoothpaste.net
+capability=service@lawn.ns.crustytoothpaste.net
+protocol=https
+host=example.com
+username=cookie-monster
+path=/foo/bar/baz.git
+wwwauth[]=Basic realm="example.com"
+wwwauth[]=Negotiate
+"#;
+        let rdr = Arc::new(Mutex::new(Cursor::new(input)));
+        let wrtr = Arc::new(Mutex::new(Cursor::new(Vec::new())));
+        let handler = GitProtocolHandler::new(rdr, wrtr, Some("git"), None, None);
+        let req = handler.parse_fill_request().unwrap();
+        assert_eq!(
+            req.username,
+            FieldRequest::LiteralBytes(Bytes::from(b"cookie-monster" as &[u8]))
+        );
+        assert_eq!(req.authtype, FieldRequest::Any);
+        assert_eq!(
+            req.protocol,
+            FieldRequest::LiteralBytes(Bytes::from(b"https" as &[u8]))
+        );
+        assert_eq!(
+            req.host,
+            FieldRequest::LiteralBytes(Bytes::from(b"example.com" as &[u8]))
+        );
+        assert_eq!(
+            req.path,
+            FieldRequest::LiteralBytes(Bytes::from(b"/foo/bar/baz.git" as &[u8]))
+        );
+        assert_eq!(req.service, FieldRequest::Any,);
+        assert_eq!(req.extra.len(), 1);
+        assert_eq!(
+            req.extra
+                .get("wwwauth@git.ns.crustytoothpaste.net")
+                .unwrap(),
+            &FieldRequest::Sequence(vec![
+                FieldRequest::LiteralBytes(Bytes::from(br#"Basic realm="example.com""# as &[u8])),
+                FieldRequest::LiteralBytes(Bytes::from(b"Negotiate" as &[u8]))
+            ])
+        );
+    }
+
+    #[test]
+    fn test_send_fill_simple() {
+        let req = CredentialRequest {
+            protocol: FieldRequest::LiteralBytes(Bytes::from(b"https" as &[u8])),
+            host: FieldRequest::LiteralBytes(Bytes::from(b"example.com" as &[u8])),
+            kind: FieldRequest::Any,
+            username: FieldRequest::Any,
+            authtype: FieldRequest::Any,
+            title: FieldRequest::Any,
+            description: FieldRequest::Any,
+            service: FieldRequest::Any,
+            id: FieldRequest::Any,
+            path: FieldRequest::Any,
+            extra: Default::default(),
+        };
+        let rdr = Arc::new(Mutex::new(Cursor::new(Vec::new())));
+        let wrtr = Arc::new(Mutex::new(Cursor::new(Vec::new())));
+        let handler = GitProtocolHandler::new(rdr, wrtr.clone(), Some("git"), None, None);
+        handler.send_fill_request(&req).unwrap();
+        let wrtr = std::mem::take(&mut *wrtr.lock().unwrap());
+        assert_eq!(
+            wrtr.into_inner(),
+            br#"protocol=https
+host=example.com
+"#
+        );
+    }
+
+    #[test]
+    fn test_parse_approve_simple() {
+        let input = br"protocol=https
+host=example.com
+username=cookie-monster
+password=abc123
+path=/foo/bar/baz.git
+";
+        let rdr = Arc::new(Mutex::new(Cursor::new(input)));
+        let wrtr = Arc::new(Mutex::new(Cursor::new(Vec::new())));
+        let handler = GitProtocolHandler::new(rdr, wrtr, Some("git"), None, None);
+        let req = handler.parse_approve_reject_request(true).unwrap().unwrap();
+        let loc = &req.location()[0];
+        assert_eq!(loc.protocol().unwrap(), "https");
+        assert_eq!(loc.host().unwrap(), "example.com");
+        assert_eq!(req.username().unwrap(), b"cookie-monster" as &[u8]);
+        assert_eq!(req.secret(), b"abc123" as &[u8]);
+        assert_eq!(loc.path().unwrap(), "/foo/bar/baz.git");
+    }
+
+    #[test]
+    fn test_parse_approve_no_cred() {
+        let input = br"protocol=https
+host=example.com
+username=cookie-monster
+path=/foo/bar/baz.git
+";
+        let rdr = Arc::new(Mutex::new(Cursor::new(input)));
+        let wrtr = Arc::new(Mutex::new(Cursor::new(Vec::new())));
+        let handler = GitProtocolHandler::new(rdr, wrtr, Some("git"), None, None);
+        assert!(handler
+            .parse_approve_reject_request(true)
+            .unwrap()
+            .is_none());
+    }
+
+    #[test]
+    fn test_parse_approve_no_cred_no_secret() {
+        let input = br"protocol=https
+host=example.com
+username=cookie-monster
+path=/foo/bar/baz.git
+";
+        let rdr = Arc::new(Mutex::new(Cursor::new(input)));
+        let wrtr = Arc::new(Mutex::new(Cursor::new(Vec::new())));
+        let handler = GitProtocolHandler::new(rdr, wrtr, Some("git"), None, None);
+        let cred = handler
+            .parse_approve_reject_request(false)
+            .unwrap()
+            .unwrap();
+        let loc = &cred.location()[0];
+        assert_eq!(loc.protocol().unwrap(), "https");
+        assert_eq!(loc.host().unwrap(), "example.com");
+        assert_eq!(cred.username().unwrap(), b"cookie-monster" as &[u8]);
+        assert_eq!(loc.path().unwrap(), "/foo/bar/baz.git");
+    }
+
+    #[test]
+    fn test_send_fill_cred() {
+        let input = Credential {
+            username: Some("cookie-monster".into()),
+            secret: Bytes::from(b"very-secret-credential" as &[u8]),
+            authtype: None,
+            kind: "api".into(),
+            location: vec![Location {
+                protocol: Some("https".into()),
+                host: Some("example.com".into()),
+                port: None,
+                path: Some("/foo/bar/baz.git".into()),
+            }],
+            service: None,
+            title: None,
+            description: None,
+            extra: BTreeMap::new(),
+            id: Bytes::from(b"abc123" as &[u8]),
+        };
+        let rdr = Arc::new(Mutex::new(Cursor::new(b"")));
+        let wrtr = Arc::new(Mutex::new(Cursor::new(Vec::new())));
+        let handler = GitProtocolHandler::new(rdr, wrtr.clone(), Some("git"), None, None);
+        handler.send_fill_response(Some(&input)).unwrap();
+        let wrtr = std::mem::take(&mut *wrtr.lock().unwrap());
+        assert_eq!(
+            wrtr.into_inner(),
+            br#"username=cookie-monster
+password=very-secret-credential
+protocol=https
+host=example.com
+path=/foo/bar/baz.git
+id=abc123
+"#
+        );
+    }
+
+    #[test]
+    fn test_send_fill_no_cred() {
+        let rdr = Arc::new(Mutex::new(Cursor::new(b"")));
+        let wrtr = Arc::new(Mutex::new(Cursor::new(Vec::new())));
+        let handler = GitProtocolHandler::new(rdr, wrtr.clone(), Some("git"), None, None);
+        handler.send_fill_response(None).unwrap();
+        let wrtr = std::mem::take(&mut *wrtr.lock().unwrap());
+        assert_eq!(wrtr.into_inner(), b"");
+    }
+}

--- a/lawn/src/credential/script.rs
+++ b/lawn/src/credential/script.rs
@@ -1,0 +1,160 @@
+#![allow(clippy::enum_variant_names)]
+
+use crate::client::Connection;
+use crate::credential::{CredentialClient, CredentialError, CredentialObject};
+use crate::error::ExtendedError;
+use crate::serializer::script::{self, ScriptDeserializer, ScriptEncoder};
+use bytes::Bytes;
+use std::borrow::{Borrow, Cow};
+use std::io;
+use std::sync::Arc;
+use thiserror::Error;
+use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader, BufWriter};
+
+pub struct ScriptRunner<
+    R: AsyncReadExt + Unpin + Send + Sync,
+    W: AsyncWriteExt + Unpin + Send + Sync,
+> {
+    reader: BufReader<R>,
+    writer: BufWriter<W>,
+    client: CredentialClient,
+}
+
+#[derive(Debug, Error)]
+pub enum Error {
+    #[error("{0}")]
+    CredentialError(#[from] CredentialError),
+    #[error("{0}")]
+    DeserializerError(#[from] script::Error),
+    #[error("{0}")]
+    IOError(#[from] io::Error),
+    #[error("unknown command: {0}")]
+    UnknownCommand(String),
+}
+
+impl ExtendedError for Error {
+    fn error_types(&self) -> Cow<'static, [Cow<'static, str>]> {
+        Cow::Borrowed(&[Cow::Borrowed("script-error")])
+    }
+    fn error_tag(&self) -> Cow<'static, str> {
+        match self {
+            Self::CredentialError(..) => "credential-error".into(),
+            Self::DeserializerError(..) => "deserialization-error".into(),
+            Self::IOError(e) => format!("{}", lawn_constants::Error::from(e)).into(),
+            Self::UnknownCommand(..) => "unknown-command".into(),
+        }
+    }
+}
+
+impl<R: AsyncReadExt + Unpin + Send + Sync, W: AsyncWriteExt + Unpin + Send + Sync>
+    ScriptRunner<R, W>
+{
+    pub async fn new(conn: Arc<Connection>, reader: R, writer: W) -> Result<Self, Error> {
+        Ok(Self {
+            client: CredentialClient::new(conn).await?,
+            reader: BufReader::new(reader),
+            writer: BufWriter::new(writer),
+        })
+    }
+
+    pub async fn run_command(&mut self) -> Result<bool, Error> {
+        let mut v = Vec::new();
+        let val = match self.reader.read_until(b'\n', &mut v).await {
+            Ok(0) => return Ok(false),
+            Ok(_) => {
+                if let Some(b'\n') = v.last() {
+                    &v[0..v.len() - 1]
+                } else {
+                    return Err(script::Error::MissingNewline.into());
+                }
+            }
+            Err(e) => return Err(e.into()),
+        };
+        let sd = ScriptDeserializer::new(val);
+        let (tag, msg) = sd.parse_owned::<(String, String)>()?;
+        match self.dispatch(tag.borrow(), msg.borrow(), &sd).await {
+            Ok(messages) => {
+                for message in messages {
+                    self.writer.write_all(tag.as_bytes()).await?;
+                    self.writer.write_all(b" ok ").await?;
+                    for (i, val) in message.iter().enumerate() {
+                        self.writer.write_all(val.as_ref()).await?;
+                        if i != message.len() - 1 {
+                            self.writer.write_all(b" ").await?;
+                        }
+                    }
+                    self.writer.write_all(b"\n").await?;
+                }
+                let _ = self.writer.flush().await;
+                Ok(true)
+            }
+            Err(e) => {
+                let se = ScriptEncoder::new();
+                self.writer.write_all(tag.as_bytes()).await?;
+                self.writer.write_all(b" err ").await?;
+                let error_types = e.error_types();
+                let error_types: &[Cow<'static, str>] = error_types.borrow();
+                let error_types = error_types.join(":");
+                self.writer.write_all(error_types.as_bytes()).await?;
+                self.writer.write_all(b" ").await?;
+                self.writer.write_all(e.error_tag().as_bytes()).await?;
+                self.writer.write_all(b" ").await?;
+                self.writer
+                    .write_all(se.encode(&format!("{}", e)).borrow())
+                    .await?;
+                self.writer.write_all(b"\n").await?;
+                let _ = self.writer.flush().await;
+                Ok(true)
+            }
+        }
+    }
+
+    async fn dispatch<'de>(
+        &self,
+        _tag: &str,
+        msg: &str,
+        de: &'de ScriptDeserializer<'de>,
+    ) -> Result<Vec<Vec<Bytes>>, Error> {
+        let se = ScriptEncoder::new();
+        match msg {
+            "mkdir" => {
+                let path: Cow<'de, [u8]> = de.parse()?;
+                let mut pieces = path.rsplitn(3, |b| *b == b'/');
+                let empty = pieces
+                    .next()
+                    .ok_or(Error::CredentialError(CredentialError::NotADirectory))?;
+                if !empty.is_empty() {
+                    return Err(Error::CredentialError(CredentialError::NotADirectory));
+                }
+                let component = pieces
+                    .next()
+                    .ok_or(Error::CredentialError(CredentialError::InvalidPath))?;
+                let dir = pieces
+                    .next()
+                    .ok_or(Error::CredentialError(CredentialError::InvalidPath))?;
+                // Add the trailing slash back.
+                let dir = Bytes::copy_from_slice(&path[0..=dir.len()]);
+                let obj = self.client.get_object(dir).await?;
+                match obj {
+                    Some(CredentialObject::Store(s)) => {
+                        s.create_vault(component).await?;
+                    }
+                    Some(CredentialObject::Vault(v)) => {
+                        v.create_directory(component).await?;
+                    }
+                    Some(CredentialObject::Directory(d)) => {
+                        d.create_directory(component).await?;
+                    }
+                    None => return Err(Error::CredentialError(CredentialError::NotFound)),
+                    _ => return Err(Error::CredentialError(CredentialError::InvalidPath)),
+                };
+                Ok(vec![vec![
+                    se.encode_to_bytes(b"mkdir" as &[u8]),
+                    se.encode_to_bytes::<[u8]>(path.borrow()),
+                ]])
+            }
+            "noop" => Ok(vec![vec![se.encode_to_bytes(b"noop" as &[u8])]]),
+            other => Err(Error::UnknownCommand(other.to_owned())),
+        }
+    }
+}

--- a/lawn/src/error/mod.rs
+++ b/lawn/src/error/mod.rs
@@ -131,6 +131,20 @@ impl From<crate::credential::CredentialError> for Error {
     }
 }
 
+/// A trait to allow logging and scripting of error values.
+pub trait ExtendedError {
+    /// The types of errors.
+    ///
+    /// This provides a list of string error types that classify this error.  For example, a
+    /// credential error that wraps an I/O error might indicate `["credential-error", "io-error"].
+    fn error_types(&self) -> Cow<'static, [Cow<'static, str>]>;
+    /// The tag of an error.
+    ///
+    /// This tag represents the error as a simple dash-divided string that indicates this specific
+    /// error.  This will usually be a kebab-case version of the error kind.
+    fn error_tag(&self) -> Cow<'static, str>;
+}
+
 #[derive(Debug)]
 pub struct WrongTypeError<T>(pub T);
 

--- a/lawn/src/error/mod.rs
+++ b/lawn/src/error/mod.rs
@@ -123,7 +123,11 @@ impl From<crate::credential::CredentialError> for Error {
                 Error::new_full(ErrorKind::MissingResponse, err, s)
             }
             E::ProtocolFailure(e) => e,
-            E::Conflict | E::NotFound | E::UnsupportedSerialization => {
+            E::Conflict
+            | E::NotFound
+            | E::UnsupportedSerialization
+            | E::InvalidPath
+            | E::NotADirectory => {
                 let s = err.to_string();
                 Error::new_full(ErrorKind::CredentialError, err, s)
             }

--- a/lawn/src/error/mod.rs
+++ b/lawn/src/error/mod.rs
@@ -243,6 +243,7 @@ pub enum ErrorKind {
     ConfigurationSpawnError,
     FSProxyError,
     CredentialError,
+    ScriptError,
 }
 
 impl From<ErrorKind> for i32 {

--- a/lawn/src/main.rs
+++ b/lawn/src/main.rs
@@ -26,6 +26,7 @@ use tokio::runtime::Handle;
 mod channel;
 mod client;
 mod config;
+mod credential;
 mod encoding;
 mod error;
 mod fs_proxy;

--- a/lawn/src/main.rs
+++ b/lawn/src/main.rs
@@ -32,6 +32,7 @@ mod error;
 mod fs_proxy;
 mod server;
 mod ssh_proxy;
+mod store;
 mod task;
 mod template;
 #[cfg(not(miri))]

--- a/lawn/src/main.rs
+++ b/lawn/src/main.rs
@@ -30,6 +30,7 @@ mod credential;
 mod encoding;
 mod error;
 mod fs_proxy;
+mod serializer;
 mod server;
 mod ssh_proxy;
 mod store;

--- a/lawn/src/serializer.rs
+++ b/lawn/src/serializer.rs
@@ -1,0 +1,1 @@
+pub mod script;

--- a/lawn/src/serializer/script.rs
+++ b/lawn/src/serializer/script.rs
@@ -1,0 +1,657 @@
+/// Tools for working with our script syntax.
+///
+/// The script syntax we use provides the ability to run multiple commands in a scripting format
+/// and get the results in a machine-parseable way.
+///
+/// All fields in this format are space-separated, and each command or response is a single line
+/// (terminated with LF).  Multiple responses are permissible if the data is best spread over
+/// multiple lines.
+///
+/// Encoding of integers may be done as decimals (no prefix), hex (with `0x`), or octal (with
+/// `0o`).  Encoding of text strings and byte strings uses percent-encoding with lowercase text for
+/// all control characters, percent and space.  Optional values are encoded as `nil` for `None` and
+/// with the value preceded by `@` for `Some`.
+///
+/// A request contains a string tag, a string command, and any number of arguments specific to the
+/// command.  A successful response to a request repeats the tag, includes the string `ok`, and
+/// then provides any relevant arguments.  An unsuccessful response to a request repeats the tag,
+/// includes the string `err`, includes a colon-separated set of error types (classes of error, if
+/// you will), a string error tag (representing the specific error), and a string error message.
+use bytes::Bytes;
+use std::borrow::Cow;
+use std::convert::{TryFrom, TryInto};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum Error {
+    #[error("invalid integer in field {0}")]
+    InvalidInteger(usize),
+    #[error("invalid boolean in field {0}")]
+    InvalidBoolean(usize),
+    #[error("invalid UTF-8 in field {0}")]
+    InvalidUTF8(usize),
+    #[error("invalid option in field {0}")]
+    InvalidOption(usize),
+    #[error("unexpected end of stream")]
+    UnexpectedEndOfStream,
+    #[error("unexpected value at offset {0}")]
+    UnexpectedValue(usize),
+    #[error("missing newline")]
+    MissingNewline,
+    #[error("unsupported type")]
+    UnsupportedType(Cow<'static, str>),
+    #[error("invalid escaped string")]
+    InvalidEscapedString(usize),
+}
+
+pub trait Encodable {
+    fn encode(&self) -> Cow<'_, [u8]>;
+    fn encode_to_bytes(&self) -> Bytes {
+        self.encode().into_owned().into()
+    }
+}
+
+#[derive(Default)]
+pub struct ScriptEncoder {}
+
+impl ScriptEncoder {
+    pub fn new() -> Self {
+        Self {}
+    }
+
+    pub fn encode<'a, T: Encodable>(&self, val: &'a T) -> Cow<'a, [u8]>
+    where
+        T: ?Sized,
+    {
+        val.encode()
+    }
+
+    pub fn encode_to_bytes<T: Encodable>(&self, val: &T) -> Bytes
+    where
+        T: ?Sized,
+    {
+        val.encode_to_bytes()
+    }
+
+    fn encode_bytes(bs: &[u8]) -> Vec<u8> {
+        const OFFSET: &[u8; 16] = b"0123456789abcdef";
+        let mut buf = [0u8; 3];
+        let mut v = Vec::with_capacity(bs.len() + 10);
+        for b in bs {
+            let encoded: &[u8] = match b {
+                b if b.is_ascii_control() => {
+                    buf = [b'%', OFFSET[(b >> 4) as usize], OFFSET[(b & 0xf) as usize]];
+                    &buf
+                }
+                b'%' | b' ' => {
+                    buf = [b'%', OFFSET[(b >> 4) as usize], OFFSET[(b & 0xf) as usize]];
+                    &buf
+                }
+                b => {
+                    buf[0] = *b;
+                    &buf[0..1]
+                }
+            };
+            v.extend(encoded);
+        }
+        v
+    }
+}
+
+macro_rules! encode_int {
+    ($a:ty) => {
+        impl Encodable for $a {
+            fn encode(&self) -> Cow<'_, [u8]> {
+                Cow::Owned(format!("{}", self).into_bytes())
+            }
+        }
+    };
+}
+
+encode_int!(u8);
+encode_int!(u16);
+encode_int!(u32);
+encode_int!(u64);
+encode_int!(u128);
+encode_int!(i8);
+encode_int!(i16);
+encode_int!(i32);
+encode_int!(i64);
+encode_int!(i128);
+
+impl Encodable for str {
+    fn encode(&self) -> Cow<'_, [u8]> {
+        Cow::Owned(ScriptEncoder::encode_bytes(self.as_bytes()))
+    }
+}
+
+impl Encodable for String {
+    fn encode(&self) -> Cow<'_, [u8]> {
+        Cow::Owned(ScriptEncoder::encode_bytes(self.as_bytes()))
+    }
+}
+
+impl Encodable for [u8] {
+    fn encode(&self) -> Cow<'_, [u8]> {
+        Cow::Owned(ScriptEncoder::encode_bytes(self))
+    }
+}
+
+impl Encodable for Vec<u8> {
+    fn encode(&self) -> Cow<'_, [u8]> {
+        Cow::Owned(ScriptEncoder::encode_bytes(self.as_slice()))
+    }
+}
+
+impl Encodable for Bytes {
+    // TODO: encode properly.
+    fn encode(&self) -> Cow<'_, [u8]> {
+        Cow::Borrowed(self.as_ref())
+    }
+}
+
+pub struct ScriptDeserializer<'de> {
+    line: &'de [u8],
+    offset: AtomicUsize,
+    field_offset: AtomicUsize,
+}
+
+impl<'de> ScriptDeserializer<'de> {
+    pub fn new(line: &'de [u8]) -> Self {
+        Self {
+            line,
+            offset: AtomicUsize::new(0),
+            field_offset: AtomicUsize::new(0),
+        }
+    }
+
+    pub fn parse<'a: 'de, T: Parseable<'a, 'de>>(&'a self) -> Result<T, Error> {
+        T::from_deserializer(self)
+    }
+
+    pub fn parse_owned<T: ParseableOwned>(&self) -> Result<T, Error> {
+        T::from_deserializer(self)
+    }
+
+    fn next_err(&self) -> Result<(&[u8], usize), Error> {
+        self.next().ok_or(Error::UnexpectedEndOfStream)
+    }
+
+    fn next(&self) -> Option<(&[u8], usize)> {
+        // The updating of offset here is not thread-safe, but we know this will never be used from
+        // multiple threads at a time.
+        let offset = self.offset.load(Ordering::Acquire);
+        if offset == self.line.len() {
+            return None;
+        }
+        match self.line[offset..].split(|b| *b == b' ').next() {
+            Some(item) => {
+                let field_offset = self.field_offset.fetch_add(1, Ordering::AcqRel);
+                if offset + item.len() >= self.line.len() {
+                    self.offset.store(self.line.len(), Ordering::Release);
+                } else {
+                    self.offset.fetch_add(item.len() + 1, Ordering::AcqRel);
+                }
+                Some((item, field_offset))
+            }
+            None => None,
+        }
+    }
+
+    // Using the same function is nicer than mixing and matching.
+    #[allow(clippy::from_str_radix_10)]
+    fn parse_signed<T: TryFrom<i128>>(&self, src: &[u8], offset: usize) -> Result<T, Error> {
+        let data = std::str::from_utf8(src).map_err(|_| Error::InvalidInteger(offset))?;
+        let value = if data.starts_with("0x") {
+            i128::from_str_radix(&data[2..], 16)
+        } else if data.starts_with("0o") {
+            i128::from_str_radix(&data[2..], 8)
+        } else {
+            i128::from_str_radix(&data, 10)
+        };
+        value
+            .ok()
+            .and_then(|v| v.try_into().ok())
+            .ok_or(Error::InvalidInteger(offset))
+    }
+
+    // Using the same function is nicer than mixing and matching.
+    #[allow(clippy::from_str_radix_10)]
+    fn parse_unsigned<T: TryFrom<u128>>(&self, src: &[u8], offset: usize) -> Result<T, Error> {
+        let data = std::str::from_utf8(src).map_err(|_| Error::InvalidInteger(offset))?;
+        let value = if data.starts_with("0x") {
+            u128::from_str_radix(&data[2..], 16)
+        } else if data.starts_with("0o") {
+            u128::from_str_radix(&data[2..], 8)
+        } else {
+            u128::from_str_radix(&data, 10)
+        };
+        value
+            .ok()
+            .and_then(|v| v.try_into().ok())
+            .ok_or(Error::InvalidInteger(offset))
+    }
+
+    fn parse_bytes<'a>(&self, src: &'a [u8], offset: usize) -> Result<Cow<'a, [u8]>, Error> {
+        if src.iter().any(|b| *b == b'%') {
+            fn parse_hex(a: u8, b: u8, offset: usize) -> Result<u8, Error> {
+                if (a.is_ascii_digit() || (b'a'..=b'f').contains(&a))
+                    && (b.is_ascii_digit() || (b'a'..=b'f').contains(&b))
+                {
+                    let seq: &[u8] = &[a, b];
+                    let s = unsafe { std::str::from_utf8_unchecked(seq) };
+                    u8::from_str_radix(s, 16).map_err(|_| Error::InvalidEscapedString(offset))
+                } else {
+                    Err(Error::InvalidEscapedString(offset))
+                }
+            }
+
+            let mut v = Vec::with_capacity(src.len() + 10);
+            let mut bs = src.iter();
+            loop {
+                let b = bs.next();
+                match b {
+                    Some(b'%') => match (bs.by_ref().next(), bs.by_ref().next()) {
+                        (Some(a), Some(b)) => v.push(parse_hex(*a, *b, offset)?),
+                        _ => return Err(Error::InvalidEscapedString(offset)),
+                    },
+                    Some(b) => v.push(*b),
+                    None => break,
+                }
+            }
+            Ok(Cow::Owned(v))
+        } else {
+            Ok(Cow::Borrowed(src))
+        }
+    }
+
+    fn parse_str<'a>(&self, src: &'a [u8], offset: usize) -> Result<Cow<'a, str>, Error> {
+        match self.parse_bytes(src, offset)? {
+            Cow::Borrowed(b) => Ok(Cow::Borrowed(
+                std::str::from_utf8(b).map_err(|_| Error::InvalidUTF8(offset))?,
+            )),
+            Cow::Owned(b) => Ok(Cow::Owned(
+                String::from_utf8(b).map_err(|_| Error::InvalidUTF8(offset))?,
+            )),
+        }
+    }
+}
+
+pub trait Parseable<'a: 'de, 'de> {
+    fn from_sequence(
+        de: &'a ScriptDeserializer<'de>,
+        src: &'de [u8],
+        offset: usize,
+    ) -> Result<Self, Error>
+    where
+        Self: Sized;
+    fn from_deserializer(de: &'a ScriptDeserializer<'de>) -> Result<Self, Error>
+    where
+        Self: Sized,
+    {
+        let (val, off) = de.next_err()?;
+        Self::from_sequence(de, val, off)
+    }
+}
+
+pub trait ParseableOwned {
+    fn from_sequence<'de>(
+        de: &ScriptDeserializer<'de>,
+        src: &'de [u8],
+        offset: usize,
+    ) -> Result<Self, Error>
+    where
+        Self: Sized;
+    fn from_deserializer(de: &ScriptDeserializer<'_>) -> Result<Self, Error>
+    where
+        Self: Sized,
+    {
+        let (val, off) = de.next_err()?;
+        Self::from_sequence(de, val, off)
+    }
+}
+
+impl<'a: 'de, 'de> Parseable<'a, 'de> for Cow<'de, str> {
+    fn from_sequence(
+        de: &'a ScriptDeserializer<'de>,
+        val: &'de [u8],
+        off: usize,
+    ) -> Result<Self, Error>
+    where
+        Self: Sized,
+    {
+        de.parse_str(val, off)
+    }
+}
+
+impl ParseableOwned for String {
+    fn from_sequence<'de>(
+        de: &ScriptDeserializer<'de>,
+        val: &'de [u8],
+        off: usize,
+    ) -> Result<Self, Error>
+    where
+        Self: Sized,
+    {
+        Ok(de.parse_str(val, off)?.into_owned())
+    }
+}
+
+impl<'a: 'de, 'de> Parseable<'a, 'de> for Cow<'de, [u8]> {
+    fn from_sequence(
+        de: &'a ScriptDeserializer<'de>,
+        val: &'de [u8],
+        off: usize,
+    ) -> Result<Self, Error>
+    where
+        Self: Sized,
+    {
+        de.parse_bytes(val, off)
+    }
+}
+
+impl ParseableOwned for Vec<u8> {
+    fn from_sequence<'de>(
+        de: &ScriptDeserializer<'de>,
+        val: &'de [u8],
+        off: usize,
+    ) -> Result<Self, Error>
+    where
+        Self: Sized,
+    {
+        Ok(de.parse_bytes(val, off)?.into_owned())
+    }
+}
+
+impl ParseableOwned for Bytes {
+    fn from_sequence<'de>(
+        de: &ScriptDeserializer<'de>,
+        val: &'de [u8],
+        off: usize,
+    ) -> Result<Self, Error>
+    where
+        Self: Sized,
+    {
+        Ok(Bytes::from(de.parse_bytes(val, off)?.into_owned()))
+    }
+}
+
+impl ParseableOwned for bool {
+    fn from_sequence<'de>(
+        _de: &ScriptDeserializer<'de>,
+        val: &'de [u8],
+        off: usize,
+    ) -> Result<Self, Error>
+    where
+        Self: Sized,
+    {
+        match val {
+            b"true" => Ok(true),
+            b"false" => Ok(false),
+            _ => Err(Error::InvalidBoolean(off)),
+        }
+    }
+}
+
+macro_rules! parse_signed {
+    ($a:ty) => {
+        impl ParseableOwned for $a {
+            fn from_sequence<'de>(
+                de: &ScriptDeserializer<'de>,
+                val: &'de [u8],
+                off: usize,
+            ) -> Result<Self, Error>
+            where
+                Self: Sized,
+            {
+                de.parse_signed(val, off)
+            }
+        }
+    };
+}
+
+macro_rules! parse_unsigned {
+    ($a:ty) => {
+        impl ParseableOwned for $a {
+            fn from_sequence<'de>(
+                de: &ScriptDeserializer<'de>,
+                val: &'de [u8],
+                off: usize,
+            ) -> Result<Self, Error>
+            where
+                Self: Sized,
+            {
+                de.parse_unsigned(val, off)
+            }
+        }
+    };
+}
+
+parse_signed!(i8);
+parse_signed!(i16);
+parse_signed!(i32);
+parse_signed!(i64);
+parse_signed!(i128);
+
+parse_unsigned!(u8);
+parse_unsigned!(u16);
+parse_unsigned!(u32);
+parse_unsigned!(u64);
+parse_unsigned!(u128);
+
+impl<T> ParseableOwned for Option<T>
+where
+    T: ParseableOwned,
+{
+    fn from_sequence<'de>(
+        de: &ScriptDeserializer<'de>,
+        val: &'de [u8],
+        off: usize,
+    ) -> Result<Self, Error>
+    where
+        Self: Sized,
+    {
+        if val == b"nil" {
+            Ok(None)
+        } else if val.starts_with(b"@") && val.len() > 1 {
+            Ok(Some(T::from_sequence(de, &val[1..], off)?))
+        } else {
+            Err(Error::InvalidOption(off))
+        }
+    }
+    fn from_deserializer(de: &ScriptDeserializer<'_>) -> Result<Self, Error>
+    where
+        Self: Sized,
+    {
+        match de.next() {
+            Some((val, off)) => Self::from_sequence(de, val, off),
+            None => Ok(None),
+        }
+    }
+}
+
+impl ParseableOwned for () {
+    fn from_sequence<'de>(
+        _de: &ScriptDeserializer<'de>,
+        _val: &'de [u8],
+        _off: usize,
+    ) -> Result<Self, Error>
+    where
+        Self: Sized,
+    {
+        Err(Error::UnsupportedType(Cow::Borrowed("tuple")))
+    }
+    fn from_deserializer(de: &ScriptDeserializer<'_>) -> Result<Self, Error>
+    where
+        Self: Sized,
+    {
+        match de.next() {
+            Some((_, off)) => Err(Error::UnexpectedValue(off)),
+            None => Ok(()),
+        }
+    }
+}
+
+macro_rules! as_next {
+    ($de:ident, $t:ty) => {{
+        let v = $de.next_err()?;
+        <$t>::from_sequence($de, v.0, v.1)?
+    }};
+}
+
+// Based on Rust's src/core/tuple.rs.
+macro_rules! tuple_impls {
+    ($T:ident) => {
+        tuple_impls!(@impl $T);
+    };
+    // Running criteria (n-ary tuple, with n >= 2)
+    ($T:ident $( $U:ident )+) => {
+        tuple_impls!($( $U )+);
+        tuple_impls!(@impl $T $( $U )+);
+    };
+    (@impl $( $T:ident )+) => {
+        //$($T)+ @
+        impl<$($T: ParseableOwned),+> ParseableOwned for ($($T,)+)
+        where
+            last_type!($($T,)+): ParseableOwned
+        {
+            fn from_sequence<'de>(
+                _de: &ScriptDeserializer<'de>,
+                _val: &'de [u8],
+                _off: usize,
+            ) -> Result<Self, Error>
+            where
+                Self: Sized,
+            {
+                Err(Error::UnsupportedType(Cow::Borrowed("tuple")))
+            }
+            fn from_deserializer(de: &ScriptDeserializer<'_>) -> Result<Self, Error>
+            where
+                Self: Sized,
+            {
+                let val = ($(as_next!(de, $T),)+);
+                Ok(val)
+            }
+        }
+
+        impl<'a: 'de, 'de, $($T: Parseable<'a, 'de>),+> Parseable<'a, 'de> for ($($T,)+)
+        where
+            last_type!($($T,)+): Parseable<'a, 'de>
+        {
+            fn from_sequence(
+                _de: &'a ScriptDeserializer<'de>,
+                _val: &'de [u8],
+                _off: usize,
+            ) -> Result<Self, Error>
+            where
+                Self: Sized,
+            {
+                Err(Error::UnsupportedType(Cow::Borrowed("tuple")))
+            }
+            fn from_deserializer(de: &'a ScriptDeserializer<'de>) -> Result<Self, Error>
+            where
+                Self: Sized,
+            {
+                let val = ($(as_next!(de, $T),)+);
+                match de.next() {
+                    Some((_, off)) => Err(Error::UnexpectedValue(off)),
+                    None => Ok(val),
+                }
+            }
+        }
+    }
+}
+
+macro_rules! last_type {
+    ($a:ident,) => { $a };
+    ($a:ident, $($rest_a:ident,)+) => { last_type!($($rest_a,)+) };
+}
+
+tuple_impls!(T U V W X Y Z A B C D E F G);
+
+#[cfg(test)]
+mod tests {
+    use super::{ScriptDeserializer, ScriptEncoder};
+    use bytes::Bytes;
+    use std::borrow::Cow;
+
+    fn parser<'de>(line: &'de [u8]) -> ScriptDeserializer<'de> {
+        ScriptDeserializer::new(line)
+    }
+
+    #[test]
+    fn deserializes_correctly() {
+        let p = parser(b"hello world");
+        assert_eq!(
+            p.parse::<(Cow<'_, str>, Cow<'_, str>)>().unwrap(),
+            (Cow::Borrowed("hello"), Cow::Borrowed("world")),
+            "hello world tuple"
+        );
+
+        let p = parser(b"hello world");
+        assert_eq!(
+            p.parse_owned::<(String, String)>().unwrap(),
+            ("hello".into(), "world".into()),
+            "hello world string tuple"
+        );
+
+        let p = parser(b"hello%20world");
+        assert_eq!(
+            p.parse_owned::<String>().unwrap(),
+            String::from("hello world"),
+            "hello world string"
+        );
+
+        let p = parser(b"hello%20world hello%20New%20Jersey");
+        assert_eq!(
+            p.parse_owned::<(Bytes, Bytes)>().unwrap(),
+            (Bytes::from("hello world"), Bytes::from("hello New Jersey")),
+            "hello world bytes"
+        );
+
+        let p = parser(b"true false 255 0xff00 0o777");
+        assert_eq!(
+            p.parse_owned::<(bool, bool, u8, u16, i32)>().unwrap(),
+            (true, false, 255, 0xff00, 0o777),
+            "mixed bools and integers"
+        );
+
+        let p = parser(b"nil @bob @0xffff");
+        assert_eq!(
+            p.parse_owned::<(Option<u8>, Option<String>, Option<u16>)>()
+                .unwrap(),
+            (None, Some("bob".into()), Some(65535)),
+            "options"
+        );
+
+        let p = parser(b"true false 255 0xff00 0o777");
+        assert_eq!(
+            p.parse_owned::<(bool, bool)>().unwrap(),
+            (true, false),
+            "mixed bools and integers, step 1"
+        );
+        assert_eq!(
+            p.parse_owned::<(u8, u16, i32)>().unwrap(),
+            (255, 0xff00, 0o777),
+            "mixed bools and integers, step 2"
+        );
+    }
+
+    #[test]
+    fn serializes_correctly() {
+        let se = ScriptEncoder::new();
+        assert_eq!(se.encode("hello").as_ref(), b"hello", "hello string");
+        assert_eq!(
+            se.encode(b"hello" as &[u8]).as_ref(),
+            b"hello",
+            "hello bytes"
+        );
+        assert_eq!(
+            se.encode(b"hello world\n!" as &[u8]).as_ref(),
+            b"hello%20world%0a!",
+            "hello bytes"
+        );
+        assert_eq!(se.encode(&0xff).as_ref(), b"255", "integer");
+    }
+}

--- a/lawn/src/server.rs
+++ b/lawn/src/server.rs
@@ -1093,7 +1093,11 @@ impl Server {
                         let id = stores.next_id();
                         stores.insert(
                             id,
-                            Arc::new(CredentialStore::new(id, state.config().clone())),
+                            Arc::new(CredentialStore::new(
+                                id,
+                                state.config().clone(),
+                                state.shared_state.clone(),
+                            )),
                         );
                         Ok(id)
                     }
@@ -1980,7 +1984,7 @@ impl Server {
 /// for cached credentials and the configuration.
 #[allow(dead_code)]
 pub struct SharedServerState {
-    credentials: RwLock<BTreeMap<Bytes, Value>>,
+    credentials: RwLock<BTreeMap<Bytes, Arc<dyn Any + Send + Sync>>>,
     config: Arc<Config>,
 }
 
@@ -1995,7 +1999,7 @@ impl SharedServerState {
 
     /// Get the credentials stored in this state.
     #[allow(dead_code)]
-    pub fn credentials(&self) -> &RwLock<BTreeMap<Bytes, Value>> {
+    pub fn credentials(&self) -> &RwLock<BTreeMap<Bytes, Arc<dyn Any + Send + Sync>>> {
         &self.credentials
     }
 

--- a/lawn/src/server.rs
+++ b/lawn/src/server.rs
@@ -1252,6 +1252,12 @@ impl Server {
                     Some(st) => st,
                     None => return Err(ResponseCode::NotFound.into()),
                 };
+                let capabilities = state.config().capabilities();
+                let desired: protocol::Capability =
+                    (Bytes::from(b"auth" as &[u8]), Some(m.method.clone())).into();
+                if !capabilities.contains(&desired) {
+                    return Err(ResponseCode::ParametersNotSupported.into());
+                }
                 match st.get(m.selector) {
                     Some(se) => match se.authenticate(m.method.clone(), m.message) {
                         Ok((resp, more)) => {

--- a/lawn/src/server.rs
+++ b/lawn/src/server.rs
@@ -6,9 +6,13 @@ use crate::config;
 use crate::config::{Config, Logger};
 use crate::encoding::{escape, path};
 use crate::error::{Error, ErrorKind};
+use crate::store::credential::CredentialStore;
+use crate::store::StoreManager;
+use crate::store::{StoreElement, StoreElementEntry};
 use crate::unix;
 use bytes::Bytes;
 use daemonize::Daemonize;
+use lawn_constants::logger::AsLogStr;
 use lawn_protocol::config::Logger as LoggerTrait;
 use lawn_protocol::handler;
 use lawn_protocol::handler::{ExtensionError, ExtensionMap, ProtocolHandler};
@@ -98,6 +102,22 @@ impl Continuations {
 
 struct ExtensionContinuation {
     off: usize,
+}
+
+struct ListStoreContinuation {
+    next: Arc<dyn StoreElementEntry + Send + Sync>,
+    iter: Box<dyn Iterator<Item = Arc<dyn StoreElementEntry + Send + Sync>> + Send + Sync>,
+}
+
+struct SearchStoreContinuation {
+    next: Arc<dyn StoreElement + Send + Sync>,
+    iter: Box<dyn Iterator<Item = Arc<dyn StoreElement + Send + Sync>> + Send + Sync>,
+}
+
+struct AuthenticateStoreElementContinuation {
+    method: Bytes,
+    id: protocol::StoreID,
+    selector: protocol::StoreSelectorID,
 }
 
 pub struct Server {
@@ -348,6 +368,7 @@ impl Server {
                 false,
             )),
             channels: Arc::new(ChannelManager::new(Some(chandeathtx))),
+            stores: Arc::new(StoreManager::new()),
             config,
             extensions: Arc::new(RwLock::new(ExtensionMap::new())),
             continuations: Continuations::new(),
@@ -537,6 +558,7 @@ impl Server {
         let handler = state.handler();
         let serializer = handler.serializer();
         let channels = state.channels();
+        let stores = state.stores();
         let logger = state.logger();
         match MessageKind::from_u32(message.kind) {
             Some(MessageKind::Capability) => {
@@ -644,6 +666,164 @@ impl Server {
                         };
                         let resp = protocol::ListExtensionRangesResponse { ranges: chunk };
                         Ok((kind, serializer.serialize_body(&resp)))
+                    }
+                    MessageKind::ListStoreElements => {
+                        let cont = state
+                            .continuations
+                            .remove::<ListStoreContinuation>(kind, id)
+                            .ok_or_else::<handler::Error, _>(|| {
+                                ResponseCode::ContinuationNotFound.into()
+                            })?;
+                        let mut it = cont.iter;
+                        let chunk: Vec<protocol::StoreElement> = [cont.next]
+                            .iter()
+                            .cloned()
+                            .chain(it.by_ref().take(99))
+                            .map(|elem| protocol::StoreElement {
+                                path: elem.path(),
+                                id: None,
+                                kind: String::from_utf8_lossy(&elem.kind()).to_string(),
+                                needs_authentication: elem.needs_authentication(),
+                                authentication_methods: None,
+                                meta: None,
+                            })
+                            .collect();
+                        let kind = match it.next() {
+                            Some(elem) => {
+                                state.continuations.insert(
+                                    MessageKind::ListStoreElements,
+                                    id,
+                                    ListStoreContinuation {
+                                        next: elem,
+                                        iter: it,
+                                    },
+                                );
+                                ResponseType::Partial
+                            }
+                            None => ResponseType::Success,
+                        };
+                        let resp = protocol::ListStoreElementsResponse { elements: chunk };
+                        Ok((kind, serializer.serialize_body(&resp)))
+                    }
+                    MessageKind::SearchStoreElements => {
+                        let cont = state
+                            .continuations
+                            .remove::<SearchStoreContinuation>(kind, id)
+                            .ok_or_else::<handler::Error, _>(|| {
+                                ResponseCode::ContinuationNotFound.into()
+                            })?;
+                        let mut it = cont.iter;
+                        let chunk: Vec<protocol::StoreElementWithBody<_>> = [cont.next]
+                            .iter()
+                            .cloned()
+                            .chain(it.by_ref().take(99))
+                            .filter_map(|elem| {
+                                let body = match elem.body() {
+                                    Ok(Some(body)) => body,
+                                    Ok(None) => return None,
+                                    Err(e) => return Some(Err(e)),
+                                };
+                                // TODO: convert when other store types are implemeneted
+                                let cse =
+                                    body.downcast_ref::<protocol::CredentialStoreElement>()?;
+                                Some(Ok(protocol::StoreElementWithBody {
+                                    path: elem.path(),
+                                    id: Some(elem.id()),
+                                    kind: String::from_utf8_lossy(&elem.kind()).to_string(),
+                                    needs_authentication: elem.needs_authentication(),
+                                    authentication_methods: None,
+                                    meta: None,
+                                    body: (*cse).clone(),
+                                }))
+                            })
+                            .collect::<Result<_, _>>()?;
+                        let kind = match it.next() {
+                            Some(elem) => {
+                                state.continuations.insert(
+                                    MessageKind::SearchStoreElements,
+                                    id,
+                                    SearchStoreContinuation {
+                                        next: elem,
+                                        iter: it,
+                                    },
+                                );
+                                ResponseType::Partial
+                            }
+                            None => ResponseType::Success,
+                        };
+                        let resp = protocol::SearchStoreElementsResponse { elements: chunk };
+                        Ok((kind, serializer.serialize_body(&resp)))
+                    }
+                    MessageKind::AuthenticateStoreElement => {
+                        let m = valid_message!(
+                            handler,
+                            protocol::ContinueRequest<protocol::AuthenticateStoreElementRequest>,
+                            message
+                        );
+                        let cont = state
+                            .continuations
+                            .remove::<AuthenticateStoreElementContinuation>(kind, id)
+                            .ok_or_else::<handler::Error, _>(|| {
+                                ResponseCode::ContinuationNotFound.into()
+                            })?;
+                        let msg = m
+                            .message
+                            .as_ref()
+                            .ok_or(ResponseCode::ParametersNotSupported)?;
+                        let st = match stores.get(cont.id) {
+                            Some(st) => st,
+                            None => return Err(ResponseCode::NotFound.into()),
+                        };
+                        if cont.method != msg.method
+                            || cont.id != msg.id
+                            || cont.selector != msg.selector
+                        {
+                            return Err(ResponseCode::Invalid.into());
+                        }
+                        match st.get(cont.selector) {
+                            Some(se) => {
+                                match se.authenticate(cont.method.clone(), msg.message.clone()) {
+                                    Ok((resp, more)) => {
+                                        let resp = protocol::AuthenticateStoreElementResponse {
+                                            method: cont.method.clone(),
+                                            message: resp,
+                                        };
+                                        let code = if more {
+                                            state.continuations.insert(
+                                                MessageKind::AuthenticateStoreElement,
+                                                id,
+                                                AuthenticateStoreElementContinuation {
+                                                    method: cont.method,
+                                                    id: cont.id,
+                                                    selector: cont.selector,
+                                                },
+                                            );
+                                            ResponseType::Partial
+                                        } else {
+                                            ResponseType::Success
+                                        };
+                                        Ok((code, serializer.serialize_body(&resp)))
+                                    }
+                                    Err(e) => {
+                                        trace!(
+                                            logger,
+                                            "server: {}: authenticate store element: error: {}",
+                                            id,
+                                            e
+                                        );
+                                        Err(e.into())
+                                    }
+                                }
+                            }
+                            None => {
+                                trace!(
+                                    logger,
+                                    "server: {}: authenticate store element: not present",
+                                    id
+                                );
+                                Err(ResponseCode::NotFound.into())
+                            }
+                        }
                     }
                     _ => Err(ResponseCode::ContinuationNotFound.into()),
                 }
@@ -870,6 +1050,541 @@ impl Server {
                 };
                 let resp = protocol::ListExtensionRangesResponse { ranges: chunk };
                 Ok((kind, serializer.serialize_body(&resp)))
+            }
+            Some(MessageKind::OpenStore) => {
+                trace!(logger, "server: {}: open store", id);
+                assert_authenticated!(handler, message);
+                let m = valid_message!(handler, protocol::OpenStoreRequest, message);
+                logger.trace(&format!("server: {}: open store: {}", id, escape(&m.kind),));
+                let kind: &[u8] = &m.kind;
+                let res: Result<_, handler::Error> = match kind {
+                    b"credential"
+                        if handler
+                            .has_capability(&protocol::Capability::StoreCredential)
+                            .await =>
+                    {
+                        let id = stores.next_id();
+                        stores.insert(id, Arc::new(CredentialStore::new(id, state.config.clone())));
+                        Ok(id)
+                    }
+                    _ => return Err(ResponseCode::ParametersNotSupported.into()),
+                };
+                match res {
+                    Ok(id) => {
+                        let r = protocol::OpenStoreResponse { id };
+                        Ok((ResponseType::Success, serializer.serialize_body(&r)))
+                    }
+                    Err(_) => {
+                        trace!(logger, "server: {}: open store: failed", id);
+                        Err(ResponseCode::InvalidParameters.into())
+                    }
+                }
+            }
+            Some(MessageKind::ListStoreElements) => {
+                trace!(logger, "server: {}: list store elements", id);
+                assert_authenticated!(handler, message);
+                let m = valid_message!(handler, protocol::ListStoreElementsRequest, message);
+                trace!(logger, "server: {}: list store elements: {}", id, m.id.0);
+                let st = match stores.get(m.id) {
+                    Some(st) => st,
+                    None => return Err(ResponseCode::NotFound.into()),
+                };
+                let se = match m.selector {
+                    protocol::StoreSelector::Path(path) => match st.acquire(path)? {
+                        Some(se) => se,
+                        None => return Err(ResponseCode::NotFound.into()),
+                    },
+                    protocol::StoreSelector::ID(selector) => match st.get(selector) {
+                        Some(se) => se,
+                        None => return Err(ResponseCode::NotFound.into()),
+                    },
+                };
+                let mut it = match (se.is_directory(), se.contents()) {
+                    (false, _) => {
+                        trace!(
+                            logger,
+                            "server: {}: list store elements: not a directory",
+                            id
+                        );
+                        return Err(ResponseCode::NotSupported.into());
+                    }
+                    (true, Err(e)) => {
+                        trace!(
+                            logger,
+                            "server: {}: list store elements: directory with error: {}",
+                            id,
+                            e
+                        );
+                        return Err(e.into());
+                    }
+                    (true, Ok(None)) => {
+                        trace!(
+                            logger,
+                            "server: {}: list store elements: directory with no data",
+                            id
+                        );
+                        return Err(ResponseCode::NotSupported.into());
+                    }
+                    (true, Ok(Some(it))) => {
+                        trace!(logger, "server: {}: list store elements: found items", id);
+                        it
+                    }
+                };
+                let chunk: Vec<_> = it
+                    .by_ref()
+                    .take(100)
+                    .map(|elem| protocol::StoreElement {
+                        path: elem.path(),
+                        id: None,
+                        kind: String::from_utf8_lossy(&elem.kind()).to_string(),
+                        needs_authentication: elem.needs_authentication(),
+                        authentication_methods: elem
+                            .authentication_metadata()
+                            .map(|meta| meta.methods().to_owned()),
+                        meta: None,
+                    })
+                    .collect();
+                trace!(
+                    logger,
+                    "server: {}: list store elements: chunk size: {}",
+                    id,
+                    chunk.len()
+                );
+                let kind = match it.next() {
+                    Some(elem) => {
+                        state.continuations.insert(
+                            MessageKind::ListStoreElements,
+                            message.id,
+                            ListStoreContinuation {
+                                next: elem,
+                                iter: it,
+                            },
+                        );
+                        ResponseType::Partial
+                    }
+                    None => ResponseType::Success,
+                };
+                let resp = protocol::ListStoreElementsResponse { elements: chunk };
+                Ok((kind, serializer.serialize_body(&resp)))
+            }
+            Some(MessageKind::AcquireStoreElement) => {
+                trace!(logger, "server: {}: acquire store element", id);
+                assert_authenticated!(handler, message);
+                let m = valid_message!(handler, protocol::AcquireStoreElementRequest, message);
+                let st = match stores.get(m.id) {
+                    Some(st) => st,
+                    None => return Err(ResponseCode::NotFound.into()),
+                };
+                let selector = match st.acquire(m.selector) {
+                    Ok(Some(se)) => se.id(),
+                    Ok(None) => {
+                        trace!(logger, "server: {}: acquire store element: not found", id);
+                        return Err(ResponseCode::NotFound.into());
+                    }
+                    Err(e) => {
+                        trace!(
+                            logger,
+                            "server: {}: acquire store element: failed: {}",
+                            id,
+                            e
+                        );
+                        return Err(e.into());
+                    }
+                };
+                let resp = protocol::AcquireStoreElementResponse { selector };
+                Ok((ResponseType::Success, serializer.serialize_body(&resp)))
+            }
+            Some(MessageKind::CloseStoreElement) => {
+                trace!(logger, "server: {}: close store element", id);
+                assert_authenticated!(handler, message);
+                let m = valid_message!(handler, protocol::CloseStoreElementRequest, message);
+                let st = match stores.get(m.id) {
+                    Some(st) => st,
+                    None => return Err(ResponseCode::NotFound.into()),
+                };
+                match st.close(m.selector) {
+                    Ok(()) => Ok((ResponseType::Success, None)),
+                    Err(e) => {
+                        trace!(logger, "server: {}: open store element: error: {}", id, e);
+                        Err(e.into())
+                    }
+                }
+            }
+            Some(MessageKind::AuthenticateStoreElement) => {
+                trace!(logger, "server: {}: authenticate store element", id);
+                assert_authenticated!(handler, message);
+                let m = valid_message!(handler, protocol::AuthenticateStoreElementRequest, message);
+                let st = match stores.get(m.id) {
+                    Some(st) => st,
+                    None => return Err(ResponseCode::NotFound.into()),
+                };
+                match st.get(m.selector) {
+                    Some(se) => match se.authenticate(m.method.clone(), m.message) {
+                        Ok((resp, more)) => {
+                            let resp = protocol::AuthenticateStoreElementResponse {
+                                method: m.method.clone(),
+                                message: resp,
+                            };
+                            let code = if more {
+                                state.continuations.insert(
+                                    MessageKind::AuthenticateStoreElement,
+                                    message.id,
+                                    AuthenticateStoreElementContinuation {
+                                        method: m.method,
+                                        id: m.id,
+                                        selector: m.selector,
+                                    },
+                                );
+                                ResponseType::Partial
+                            } else {
+                                ResponseType::Success
+                            };
+                            Ok((code, serializer.serialize_body(&resp)))
+                        }
+                        Err(e) => {
+                            trace!(
+                                logger,
+                                "server: {}: authenticate store element: error: {}",
+                                id,
+                                e
+                            );
+                            Err(e.into())
+                        }
+                    },
+                    None => {
+                        trace!(
+                            logger,
+                            "server: {}: authenticate store element: not present",
+                            id
+                        );
+                        Err(ResponseCode::NotFound.into())
+                    }
+                }
+            }
+            Some(MessageKind::CreateStoreElement) => {
+                trace!(logger, "server: {}: create store element", id);
+                assert_authenticated!(handler, message);
+                let m = valid_message!(handler, protocol::StoreElementBareRequest, message);
+                let st = match stores.get(m.id) {
+                    Some(st) => st,
+                    None => return Err(ResponseCode::NotFound.into()),
+                };
+                let path = match m.selector {
+                    protocol::StoreSelector::Path(path) => path,
+                    protocol::StoreSelector::ID(_) => {
+                        return Err(ResponseCode::ParametersNotSupported.into())
+                    }
+                };
+                let cred;
+                let value: Option<&dyn Any> = match &*m.kind {
+                    "directory" => None,
+                    "credential" => {
+                        cred = valid_message!(
+                            handler,
+                            protocol::CreateStoreElementRequest<protocol::CredentialStoreElement>,
+                            message
+                        );
+                        Some(&cred.body)
+                    }
+                    _ => {
+                        trace!(
+                            logger,
+                            "server: {}: create store element: unsupported type: {}",
+                            id,
+                            m.kind
+                        );
+                        return Err(ResponseCode::ParametersNotSupported.into());
+                    }
+                };
+                trace!(
+                    logger,
+                    "server: {}: create store element: creating element of type {} at {}",
+                    id,
+                    m.kind,
+                    path.as_ref().as_log_str(),
+                );
+                match st.create(path, &m.kind, m.meta.as_ref(), value) {
+                    Ok(se) => {
+                        let elem = protocol::StoreElement {
+                            path: se.path(),
+                            id: Some(se.id()),
+                            kind: String::from_utf8_lossy(se.kind()).to_string(),
+                            needs_authentication: se.needs_authentication(),
+                            authentication_methods: se
+                                .authentication_metadata()
+                                .map(|m| m.methods().to_owned()),
+                            meta: se.meta().as_deref().map(ToOwned::to_owned),
+                        };
+                        Ok((ResponseType::Success, serializer.serialize_body(&elem)))
+                    }
+                    Err(e) => {
+                        trace!(logger, "server: {}: create store element: error: {}", id, e);
+                        Err(e.into())
+                    }
+                }
+            }
+            Some(MessageKind::UpdateStoreElement) => {
+                trace!(logger, "server: {}: update store element", id);
+                assert_authenticated!(handler, message);
+                let m = valid_message!(handler, protocol::StoreElementBareRequest, message);
+                let st = match stores.get(m.id) {
+                    Some(st) => st,
+                    None => return Err(ResponseCode::NotFound.into()),
+                };
+                let se = match m.selector {
+                    protocol::StoreSelector::Path(path) => match st.acquire(path)? {
+                        Some(se) => se,
+                        None => return Err(ResponseCode::NotFound.into()),
+                    },
+                    protocol::StoreSelector::ID(selector) => match st.get(selector) {
+                        Some(se) => se,
+                        None => return Err(ResponseCode::NotFound.into()),
+                    },
+                };
+                if m.kind.as_bytes() != se.kind()
+                    || m.needs_authentication.is_some()
+                    || m.authentication_methods.is_some()
+                {
+                    trace!(
+                        logger,
+                        "server: {}: update store element: unsupported update data: {}",
+                        id,
+                        m.kind
+                    );
+                    return Err(ResponseCode::ParametersNotSupported.into());
+                }
+                let cred;
+                let value: Option<&dyn Any> = match &*m.kind {
+                    "directory" => None,
+                    "credential" => {
+                        cred = valid_message!(
+                            handler,
+                            protocol::UpdateStoreElementRequest<protocol::CredentialStoreElement>,
+                            message
+                        );
+                        Some(&cred.body)
+                    }
+                    _ => {
+                        trace!(
+                            logger,
+                            "server: {}: update store element: unsupported type: {}",
+                            id,
+                            m.kind
+                        );
+                        return Err(ResponseCode::ParametersNotSupported.into());
+                    }
+                };
+                match se.update(m.meta.as_ref(), value) {
+                    Ok(_) => Ok((ResponseType::Success, None)),
+                    Err(e) => {
+                        trace!(logger, "server: {}: update store element: error: {}", id, e);
+                        Err(e.into())
+                    }
+                }
+            }
+            Some(MessageKind::DeleteStoreElement) => {
+                trace!(logger, "server: {}: delete store element", id);
+                assert_authenticated!(handler, message);
+                let m = valid_message!(handler, protocol::DeleteStoreElementRequest, message);
+                let st = match stores.get(m.id) {
+                    Some(st) => st,
+                    None => return Err(ResponseCode::NotFound.into()),
+                };
+                let selector = match m.selector {
+                    protocol::StoreSelector::Path(path) => match st.acquire(path)? {
+                        Some(se) => se.id(),
+                        None => return Err(ResponseCode::NotFound.into()),
+                    },
+                    protocol::StoreSelector::ID(selector) => selector,
+                };
+                match st.delete(selector) {
+                    Ok(()) => Ok((ResponseType::Success, None)),
+                    Err(e) => {
+                        trace!(logger, "server: {}: delete store element: error: {}", id, e);
+                        Err(e.into())
+                    }
+                }
+            }
+            Some(MessageKind::ReadStoreElement) => {
+                trace!(logger, "server: {}: read store element", id);
+                assert_authenticated!(handler, message);
+                let m = valid_message!(handler, protocol::ReadStoreElementRequest, message);
+                let st = match stores.get(m.id) {
+                    Some(st) => st,
+                    None => return Err(ResponseCode::NotFound.into()),
+                };
+                let se = match m.selector {
+                    protocol::StoreSelector::Path(path) => match st.acquire(path)? {
+                        Some(se) => se,
+                        None => return Err(ResponseCode::NotFound.into()),
+                    },
+                    protocol::StoreSelector::ID(selector) => match st.get(selector) {
+                        Some(se) => se,
+                        None => return Err(ResponseCode::NotFound.into()),
+                    },
+                };
+                let elem = protocol::StoreElement {
+                    path: se.path(),
+                    id: Some(se.id()),
+                    kind: String::from_utf8_lossy(se.kind()).to_string(),
+                    needs_authentication: se.needs_authentication(),
+                    authentication_methods: se
+                        .authentication_metadata()
+                        .map(|m| m.methods().to_owned()),
+                    meta: se.meta().as_deref().map(ToOwned::to_owned),
+                };
+                match se.kind() {
+                    b"directory" => Ok((ResponseType::Success, serializer.serialize_body(&elem))),
+                    b"credential" => {
+                        let body = se.body()?;
+                        let cse: protocol::CredentialStoreElement = match body
+                            .map(|b| b.downcast::<protocol::CredentialStoreElement>().ok())
+                        {
+                            Some(Some(cse)) => *cse,
+                            Some(None) => {
+                                trace!(
+                                    logger,
+                                    "server: {}: read store element: unable to cast",
+                                    id,
+                                );
+                                return Err(ResponseCode::InternalError.into());
+                            }
+                            None => {
+                                trace!(
+                                    logger,
+                                    "server: {}: read store element: no body provided",
+                                    id,
+                                );
+                                return Err(ResponseCode::NotFound.into());
+                            }
+                        };
+                        let resp = protocol::StoreElementWithBody::new(elem, cse);
+                        Ok((ResponseType::Success, serializer.serialize_body(&resp)))
+                    }
+                    _ => {
+                        trace!(
+                            logger,
+                            "server: {}: read store element: unsupported type: {}",
+                            id,
+                            se.kind().as_log_str()
+                        );
+                        Err(ResponseCode::ParametersNotSupported.into())
+                    }
+                }
+            }
+            Some(MessageKind::SearchStoreElements) => {
+                trace!(logger, "server: {}: search store elements", id);
+                assert_authenticated!(handler, message);
+                let m = valid_message!(handler, protocol::SearchStoreElementsBareRequest, message);
+                let st = match stores.get(m.id) {
+                    Some(st) => st,
+                    None => return Err(ResponseCode::NotFound.into()),
+                };
+                trace!(
+                    logger,
+                    "server: {}: search store elements: selector {:?}",
+                    id,
+                    m.selector
+                );
+                let se = match m.selector {
+                    protocol::StoreSelector::Path(path) => match st.acquire(path)? {
+                        Some(se) => se,
+                        None => return Err(ResponseCode::NotFound.into()),
+                    },
+                    protocol::StoreSelector::ID(selector) => match st.get(selector) {
+                        Some(se) => se,
+                        None => return Err(ResponseCode::NotFound.into()),
+                    },
+                };
+                match m.kind.as_deref() {
+                    Some("credential") => {
+                        let m = valid_message!(
+                            handler,
+                            protocol::SearchStoreElementsRequest<
+                                protocol::CredentialStoreSearchElement,
+                            >,
+                            message
+                        );
+                        let mut it = match tokio::task::spawn_blocking(move || {
+                            let body: Option<&dyn Any> = match &m.body {
+                                Some(b) => Some(b),
+                                None => None,
+                            };
+                            se.search(m.kind.map(|k| k.into()), body, m.recurse)
+                        })
+                        .await
+                        {
+                            Ok(Ok(res)) => res,
+                            Ok(Err(e)) => {
+                                trace!(
+                                    logger,
+                                    "server: {}: search store element: search error: {}",
+                                    id,
+                                    e,
+                                );
+                                return Err(e.into());
+                            }
+                            Err(_) => return Err(ResponseCode::InternalError.into()),
+                        };
+                        let chunk = it
+                            .by_ref()
+                            .take(100)
+                            .filter_map(|elem| {
+                                let body = match elem.body() {
+                                    Ok(Some(body)) => body,
+                                    Ok(None) => return None,
+                                    Err(e) => return Some(Err(e)),
+                                };
+                                let cse =
+                                    body.downcast_ref::<protocol::CredentialStoreElement>()?;
+                                Some(Ok(protocol::StoreElementWithBody {
+                                    path: elem.path(),
+                                    id: Some(elem.id()),
+                                    kind: String::from_utf8_lossy(&elem.kind()).to_string(),
+                                    needs_authentication: elem.needs_authentication(),
+                                    authentication_methods: None,
+                                    meta: None,
+                                    body: cse.clone(),
+                                }))
+                            })
+                            .collect::<Result<Vec<_>, _>>()?;
+                        let kind = match it.next() {
+                            Some(elem) => {
+                                state.continuations.insert(
+                                    MessageKind::ListStoreElements,
+                                    message.id,
+                                    SearchStoreContinuation {
+                                        next: elem,
+                                        iter: it,
+                                    },
+                                );
+                                ResponseType::Partial
+                            }
+                            None => ResponseType::Success,
+                        };
+                        let resp = protocol::SearchStoreElementsResponse { elements: chunk };
+                        Ok((kind, serializer.serialize_body(&resp)))
+                    }
+                    _ => {
+                        trace!(
+                            logger,
+                            "server: {}: search store element: unsupported type: {}",
+                            id,
+                            se.kind().as_log_str()
+                        );
+                        Err(ResponseCode::ParametersNotSupported.into())
+                    }
+                }
+            }
+            Some(MessageKind::CloseStore) => {
+                logger.trace(&format!("server: {}: close store", id));
+                assert_authenticated!(handler, message);
+                let m = valid_message!(handler, protocol::CloseStoreRequest, message);
+                match stores.remove(m.id) {
+                    Some(ch) => std::mem::drop(ch),
+                    None => return Err(ResponseCode::NotFound.into()),
+                };
+                Ok((ResponseType::Success, None))
             }
             Some(_) | None => {
                 logger.trace(&format!(
@@ -1231,6 +1946,7 @@ impl Server {
 struct ServerState<T: AsyncRead + Unpin, U: AsyncWrite + Unpin> {
     handler: Arc<ProtocolHandler<T, U>>,
     channels: Arc<ChannelManager>,
+    stores: Arc<StoreManager>,
     config: Arc<Config>,
     extensions: Arc<RwLock<ExtensionMap>>,
     continuations: Continuations,
@@ -1243,6 +1959,10 @@ impl<T: AsyncRead + Unpin, U: AsyncWrite + Unpin> ServerState<T, U> {
 
     fn channels(&self) -> Arc<ChannelManager> {
         self.channels.clone()
+    }
+
+    fn stores(&self) -> Arc<StoreManager> {
+        self.stores.clone()
     }
 
     fn config(&self) -> Arc<Config> {

--- a/lawn/src/server.rs
+++ b/lawn/src/server.rs
@@ -1607,8 +1607,8 @@ impl Server {
         if allowed != requested {
             return Err(ResponseCode::ParametersNotSupported.into());
         }
-        let args = match &m.args {
-            Some(args) if !args.is_empty() => args,
+        let args: Arc<[Bytes]> = match &m.args {
+            Some(args) if !args.is_empty() => args.clone().into(),
             _ => return Err(ResponseCode::InvalidParameters.into()),
         };
         let config = state.config();
@@ -1616,7 +1616,8 @@ impl Server {
             Some(cmd) => cmd,
             None => return Err(ResponseCode::NotFound.into()),
         };
-        let ctx = config.template_context(m.env.as_ref(), Some(args));
+        let env = m.env.as_ref().map(|e| Arc::new(e.clone()));
+        let ctx = config.template_context(env, Some(args.clone()));
         let logger = state.logger();
         let channels = state.channels();
         let cmd = match config::Command::new(&cfgcmd, &ctx) {

--- a/lawn/src/store.rs
+++ b/lawn/src/store.rs
@@ -7,6 +7,8 @@ use std::collections::{BTreeMap, HashMap, VecDeque};
 use std::sync::Mutex;
 use std::sync::{Arc, RwLock};
 
+pub mod credential;
+
 pub struct StoreManager {
     map: RwLock<HashMap<StoreID, Arc<dyn Store + Send + Sync>>>,
     id: Mutex<u32>,

--- a/lawn/src/store.rs
+++ b/lawn/src/store.rs
@@ -1,0 +1,313 @@
+use bytes::Bytes;
+use lawn_protocol::protocol::{self, StoreID, StoreSearchRecursionLevel, StoreSelectorID};
+use serde_cbor::Value;
+use std::any::Any;
+use std::borrow::Cow;
+use std::collections::{BTreeMap, HashMap, VecDeque};
+use std::sync::Mutex;
+use std::sync::{Arc, RwLock};
+
+pub struct StoreManager {
+    map: RwLock<HashMap<StoreID, Arc<dyn Store + Send + Sync>>>,
+    id: Mutex<u32>,
+}
+
+impl StoreManager {
+    pub fn new() -> Self {
+        Self {
+            map: RwLock::new(HashMap::new()),
+            id: Mutex::new(0),
+        }
+    }
+
+    pub fn next_id(&self) -> StoreID {
+        let mut g = self.id.lock().unwrap();
+        let val = *g;
+        *g += 1;
+        StoreID(val)
+    }
+
+    pub fn insert(&self, id: StoreID, ch: Arc<dyn Store + Send + Sync>) {
+        let mut g = self.map.write().unwrap();
+        g.insert(id, ch);
+    }
+
+    pub fn remove(&self, id: StoreID) -> Option<Arc<dyn Store + Send + Sync>> {
+        let mut g = self.map.write().unwrap();
+        g.remove(&id)
+    }
+
+    pub fn get(&self, id: StoreID) -> Option<Arc<dyn Store + Send + Sync>> {
+        let g = self.map.read().unwrap();
+        g.get(&id).map(Arc::clone)
+    }
+}
+
+pub struct StorePath<T: AsRef<[u8]>>(T);
+
+impl<T: AsRef<[u8]>> StorePath<T> {
+    pub fn new(path: T) -> Option<Self> {
+        let pr = path.as_ref();
+        if !pr.starts_with(b"/") || pr.contains(&b'%') {
+            return None;
+        }
+        Some(Self(path))
+    }
+
+    pub fn components(&self) -> Vec<Bytes> {
+        self.0
+            .as_ref()
+            .split(|x| *x == b'/')
+            .map(Bytes::copy_from_slice)
+            .collect()
+    }
+
+    pub fn into_inner(self) -> T {
+        self.0
+    }
+}
+
+impl StorePath<Bytes> {
+    pub fn from_components<U: AsRef<[u8]>>(components: &[U]) -> Option<Self> {
+        if !components[0].as_ref().is_empty() {
+            return None;
+        }
+        let size = components.iter().map(|c| c.as_ref().len()).sum::<usize>() + components.len();
+        let mut v: Vec<u8> = Vec::with_capacity(size);
+        for (i, c) in components.iter().enumerate() {
+            let c = c.as_ref();
+            if c.contains(&b'%') {
+                return None;
+            }
+            v.extend(c);
+            if i + 1 != components.len() {
+                v.extend(b"/");
+            }
+        }
+        Some(StorePath(v.into()))
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct StoreAuthenticationMetadata {
+    methods: Vec<Bytes>,
+}
+
+impl StoreAuthenticationMetadata {
+    pub fn methods(&self) -> &[Bytes] {
+        &self.methods
+    }
+}
+
+pub trait StoreElementEntry {
+    fn store_id(&self) -> StoreID;
+    fn path(&self) -> Bytes;
+    fn is_directory(&self) -> bool;
+    fn kind(&self) -> Bytes;
+    fn needs_authentication(&self) -> Option<bool>;
+    fn authentication_metadata(&self) -> Option<StoreAuthenticationMetadata>;
+}
+
+impl<T: StoreElement> StoreElementEntry for T {
+    fn store_id(&self) -> StoreID {
+        StoreElement::store_id(self)
+    }
+
+    fn path(&self) -> Bytes {
+        StoreElement::path(self)
+    }
+
+    fn is_directory(&self) -> bool {
+        StoreElement::is_directory(self)
+    }
+
+    fn kind(&self) -> Bytes {
+        Bytes::from(StoreElement::kind(self).to_vec())
+    }
+
+    fn needs_authentication(&self) -> Option<bool> {
+        StoreElement::needs_authentication(self)
+    }
+
+    fn authentication_metadata(&self) -> Option<StoreAuthenticationMetadata> {
+        StoreElement::authentication_metadata(self)
+    }
+}
+
+pub struct PlainStoreElementEntry {
+    store_id: StoreID,
+    path: Bytes,
+    kind: Bytes,
+    auth: Option<bool>,
+    auth_meta: Option<StoreAuthenticationMetadata>,
+}
+
+impl StoreElementEntry for PlainStoreElementEntry {
+    fn store_id(&self) -> StoreID {
+        self.store_id
+    }
+
+    fn path(&self) -> Bytes {
+        self.path.clone()
+    }
+
+    fn is_directory(&self) -> bool {
+        self.path.ends_with(b"/")
+    }
+
+    fn kind(&self) -> Bytes {
+        self.kind.clone()
+    }
+
+    fn needs_authentication(&self) -> Option<bool> {
+        self.auth
+    }
+
+    fn authentication_metadata(&self) -> Option<StoreAuthenticationMetadata> {
+        self.auth_meta.clone()
+    }
+}
+
+type BoxedStoreElementEntryIterator =
+    Box<dyn Iterator<Item = Arc<dyn StoreElementEntry + Send + Sync>> + Send + Sync>;
+
+pub trait StoreElement {
+    fn store_id(&self) -> StoreID;
+    fn id(&self) -> StoreSelectorID;
+    fn path(&self) -> Bytes;
+
+    fn is_directory(&self) -> bool {
+        self.path().ends_with(b"/")
+    }
+
+    fn kind(&self) -> &[u8];
+    fn contents(&self) -> Result<Option<BoxedStoreElementEntryIterator>, protocol::Error>;
+    fn needs_authentication(&self) -> Option<bool>;
+    fn authentication_metadata(&self) -> Option<StoreAuthenticationMetadata>;
+    /// Authenticate to this store entry.
+    ///
+    /// `kind` is the authentication method used, and `message` is the client-side message, which
+    /// may be `None` if the server is expected to speak first.
+    ///
+    /// Returns the server message and a boolean indicating whether more data is expected on
+    /// success.
+    fn authenticate(
+        &self,
+        kind: Bytes,
+        message: Option<Bytes>,
+    ) -> Result<(Option<Bytes>, bool), protocol::Error>;
+    fn update(
+        self: Arc<Self>,
+        meta: Option<&BTreeMap<Bytes, Value>>,
+        body: Option<&(dyn Any + 'static)>,
+    ) -> Result<(), protocol::Error>;
+    fn meta(&self) -> Option<Cow<'_, BTreeMap<Bytes, Value>>>;
+    fn body(&self) -> Result<Option<Box<dyn Any + 'static>>, protocol::Error>;
+    fn delete(&self) -> Result<(), protocol::Error>;
+    fn create(
+        self: Arc<Self>,
+        path: Option<Bytes>,
+        kind: &str,
+        meta: Option<&BTreeMap<Bytes, Value>>,
+        body: Option<&dyn Any>,
+    ) -> Result<Arc<dyn StoreElement + Send + Sync>, protocol::Error>;
+    fn search(
+        self: Arc<Self>,
+        kind: Option<Bytes>,
+        pattern: Option<&(dyn Any + 'static)>,
+        recurse: StoreSearchRecursionLevel,
+    ) -> Result<
+        Box<dyn Iterator<Item = Arc<dyn StoreElement + Send + Sync>> + Send + Sync>,
+        protocol::Error,
+    >;
+}
+
+pub trait Store {
+    fn id(&self) -> StoreID;
+    fn acquire(
+        &self,
+        path: Bytes,
+    ) -> Result<Option<Arc<dyn StoreElement + Send + Sync>>, protocol::Error>;
+    fn get(&self, id: StoreSelectorID) -> Option<Arc<dyn StoreElement + Send + Sync>>;
+    fn close(&self, id: StoreSelectorID) -> Result<(), protocol::Error>;
+    fn delete(&self, id: StoreSelectorID) -> Result<(), protocol::Error>;
+    fn create(
+        &self,
+        path: Bytes,
+        kind: &str,
+        meta: Option<&BTreeMap<Bytes, Value>>,
+        body: Option<&(dyn Any + 'static)>,
+    ) -> Result<Arc<dyn StoreElement + Send + Sync>, protocol::Error>;
+    fn search(
+        &self,
+        id: StoreSelectorID,
+        kind: Option<Bytes>,
+        pattern: Option<&(dyn Any + 'static)>,
+        recurse: StoreSearchRecursionLevel,
+    ) -> Result<
+        Box<dyn Iterator<Item = Arc<dyn StoreElement + Send + Sync>> + Send + Sync>,
+        protocol::Error,
+    >;
+}
+
+pub struct StoreElementEntryIterator {
+    vec: VecDeque<Arc<dyn StoreElementEntry + Send + Sync>>,
+}
+
+impl StoreElementEntryIterator {
+    fn new(v: VecDeque<Arc<dyn StoreElementEntry + Send + Sync>>) -> Self {
+        Self { vec: v }
+    }
+}
+
+impl Iterator for StoreElementEntryIterator {
+    type Item = Arc<dyn StoreElementEntry + Send + Sync>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.vec.pop_front()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::StorePath;
+
+    #[test]
+    fn storepath_parses_components() {
+        let cases: &[(&[u8], Option<&[u8]>, Option<&[&[u8]]>)] = &[
+            (b"/", Some(b"/"), Some(&[b"", b""])),
+            (b"/git", Some(b"/git"), Some(&[b"", b"git"])),
+            (b"/git/", Some(b"/git/"), Some(&[b"", b"git", b""])),
+            (b"/%/", None, None),
+            (b"git", None, None),
+            (
+                b"/git/\xfe\xff/",
+                Some(b"/git/\xfe\xff/"),
+                Some(&[b"", b"git", b"\xfe\xff", b""]),
+            ),
+        ];
+
+        for (input, inner, components) in cases {
+            let path = StorePath::new(*input);
+            let computed_components = path.as_ref().map(|p| p.components());
+            let computed_path = path.map(|p| p.into_inner());
+            let sliced_components: Option<Vec<&[u8]>> = computed_components
+                .as_ref()
+                .map(|c| c.iter().map(|b| b.as_ref()).collect());
+
+            assert_eq!(computed_path, *inner, "computed path matches");
+            assert_eq!(
+                sliced_components.as_deref(),
+                *components,
+                "computed components match"
+            );
+
+            if let Some(components) = sliced_components {
+                let newpath = StorePath::from_components(&*components)
+                    .unwrap()
+                    .into_inner();
+                assert_eq!(newpath, inner.unwrap(), "computed from components matches");
+            }
+        }
+    }
+}

--- a/lawn/src/store/credential.rs
+++ b/lawn/src/store/credential.rs
@@ -1,0 +1,687 @@
+use super::{
+    BoxedStoreElementEntryIterator, PlainStoreElementEntry, Store, StoreAuthenticationMetadata,
+    StoreElement, StoreElementEntry, StoreElementEntryIterator, StorePath,
+    StoreSearchRecursionLevel,
+};
+use crate::config::{Config, CredentialBackendType};
+use crate::credential::CredentialParserError;
+use bytes::Bytes;
+use format_bytes::format_bytes;
+use lawn_protocol::protocol::{self, ResponseCode, StoreID, StoreSelectorID};
+use serde_cbor::Value;
+use std::any::Any;
+use std::borrow::Cow;
+use std::collections::BTreeMap;
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::{Arc, Mutex, RwLock};
+
+pub mod git;
+pub mod helpers;
+
+pub trait CredentialBackend {
+    fn name(&self) -> &[u8];
+    fn vaults(&self) -> Result<Cow<'_, [Bytes]>, CredentialParserError>;
+    fn vault_by_name(
+        self: Arc<Self>,
+        store_id: StoreID,
+        name: &[u8],
+    ) -> Result<Option<Arc<dyn CredentialVault + Send + Sync>>, CredentialParserError>;
+    fn next_handle(
+        self: Arc<Self>,
+        store_id: StoreID,
+        path: Bytes,
+    ) -> Arc<dyn CredentialBackendHandle + Send + Sync>;
+    fn handle_from_id(
+        self: Arc<Self>,
+        store_id: StoreID,
+        id: StoreSelectorID,
+    ) -> Option<Arc<dyn CredentialBackendHandle + Send + Sync>>;
+    fn to_handle(
+        self: Arc<Self>,
+        store_id: StoreID,
+    ) -> Arc<dyn CredentialBackendHandle + Send + Sync>;
+    fn acquire_at_path(
+        self: Arc<Self>,
+        store_id: StoreID,
+        path: Bytes,
+    ) -> Result<Option<Arc<dyn CredentialBackendHandle + Send + Sync>>, CredentialParserError>;
+    fn needs_authentication(&self) -> Option<bool>;
+    fn authentication_metadata(&self) -> Option<StoreAuthenticationMetadata>;
+}
+
+pub trait CredentialBackendHandle {
+    fn config(&self) -> Arc<Config>;
+    fn store_id(&self) -> StoreID;
+    fn id(&self) -> StoreSelectorID;
+    fn to_store_element_entry(self: Arc<Self>) -> Arc<dyn StoreElementEntry + Send + Sync>;
+    fn to_store_element(self: Arc<Self>) -> Arc<dyn StoreElement + Send + Sync>;
+    fn backend_name(&self) -> &[u8];
+    fn backend_vaults(&self) -> Result<Cow<'_, [Bytes]>, CredentialParserError>;
+    fn needs_authentication(&self) -> Option<bool>;
+    fn authentication_metadata(&self) -> Option<StoreAuthenticationMetadata>;
+    fn authenticate(
+        &self,
+        kind: Bytes,
+        message: Option<Bytes>,
+    ) -> Result<(Option<Bytes>, bool), protocol::Error>;
+    fn update(
+        self: Arc<Self>,
+        meta: Option<&BTreeMap<Bytes, Value>>,
+        body: Option<&dyn Any>,
+    ) -> Result<(), protocol::Error>;
+    fn delete(&self) -> Result<(), protocol::Error>;
+    fn meta(&self) -> Option<Cow<'_, BTreeMap<Bytes, Value>>>;
+    fn body(&self) -> Result<Option<Box<dyn Any + 'static>>, protocol::Error>;
+    fn create(
+        self: Arc<Self>,
+        path: Option<Bytes>,
+        kind: &str,
+        meta: Option<&BTreeMap<Bytes, Value>>,
+        body: Option<&(dyn Any + 'static)>,
+    ) -> Result<Arc<dyn StoreElement + Send + Sync>, protocol::Error>;
+    fn search(
+        self: Arc<Self>,
+        kind: Option<Bytes>,
+        pattern: Option<&(dyn Any + 'static)>,
+        recurse: StoreSearchRecursionLevel,
+    ) -> Result<
+        Box<dyn Iterator<Item = Arc<dyn StoreElement + Send + Sync>> + Send + Sync>,
+        protocol::Error,
+    >;
+    fn contents(&self) -> Result<Option<BoxedStoreElementEntryIterator>, protocol::Error>;
+}
+
+#[derive(Clone)]
+struct TopLevelCredentialBackendHandle {
+    store_id: StoreID,
+    id: StoreSelectorID,
+    config: Arc<Config>,
+    backends: Arc<Mutex<BTreeMap<Bytes, Arc<dyn CredentialBackend + Send + Sync>>>>,
+}
+
+impl StoreElement for TopLevelCredentialBackendHandle {
+    fn store_id(&self) -> StoreID {
+        self.store_id
+    }
+
+    fn id(&self) -> StoreSelectorID {
+        self.id
+    }
+
+    fn path(&self) -> Bytes {
+        Bytes::from(b"/" as &[u8])
+    }
+
+    fn kind(&self) -> &[u8] {
+        b"directory"
+    }
+
+    fn contents(
+        &self,
+    ) -> Result<
+        Option<Box<dyn Iterator<Item = Arc<dyn StoreElementEntry + Send + Sync>> + Send + Sync>>,
+        protocol::Error,
+    > {
+        CredentialBackendHandle::contents(self)
+    }
+
+    fn needs_authentication(&self) -> Option<bool> {
+        CredentialBackendHandle::needs_authentication(self)
+    }
+
+    fn authentication_metadata(&self) -> Option<StoreAuthenticationMetadata> {
+        CredentialBackendHandle::authentication_metadata(self)
+    }
+
+    fn authenticate(
+        &self,
+        kind: Bytes,
+        message: Option<Bytes>,
+    ) -> Result<(Option<Bytes>, bool), protocol::Error> {
+        CredentialBackendHandle::authenticate(self, kind, message)
+    }
+
+    fn update(
+        self: Arc<Self>,
+        meta: Option<&BTreeMap<Bytes, Value>>,
+        body: Option<&(dyn Any + 'static)>,
+    ) -> Result<(), protocol::Error> {
+        CredentialBackendHandle::update(self, meta, body)
+    }
+
+    fn meta(&self) -> Option<Cow<'_, BTreeMap<Bytes, Value>>> {
+        CredentialBackendHandle::meta(self)
+    }
+
+    fn body(&self) -> Result<Option<Box<dyn Any + 'static>>, protocol::Error> {
+        CredentialBackendHandle::body(self)
+    }
+
+    fn delete(&self) -> Result<(), protocol::Error> {
+        CredentialBackendHandle::delete(self)
+    }
+
+    fn search(
+        self: Arc<Self>,
+        kind: Option<Bytes>,
+        pattern: Option<&(dyn Any + 'static)>,
+        recurse: StoreSearchRecursionLevel,
+    ) -> Result<
+        Box<dyn Iterator<Item = Arc<dyn StoreElement + Send + Sync>> + Send + Sync>,
+        protocol::Error,
+    > {
+        CredentialBackendHandle::search(self, kind, pattern, recurse)
+    }
+
+    fn create(
+        self: Arc<Self>,
+        path: Option<Bytes>,
+        kind: &str,
+        meta: Option<&BTreeMap<Bytes, Value>>,
+        body: Option<&(dyn Any + 'static)>,
+    ) -> Result<Arc<dyn StoreElement + Send + Sync>, protocol::Error> {
+        CredentialBackendHandle::create(self, path, kind, meta, body)
+    }
+}
+
+impl CredentialBackendHandle for TopLevelCredentialBackendHandle {
+    fn config(&self) -> Arc<Config> {
+        self.config.clone()
+    }
+
+    fn store_id(&self) -> StoreID {
+        self.store_id
+    }
+
+    fn id(&self) -> StoreSelectorID {
+        self.id
+    }
+
+    fn to_store_element_entry(self: Arc<Self>) -> Arc<dyn StoreElementEntry + Send + Sync> {
+        Arc::new(Self {
+            store_id: self.store_id,
+            id: self.id,
+            config: self.config.clone(),
+            backends: self.backends.clone(),
+        })
+    }
+
+    fn to_store_element(self: Arc<Self>) -> Arc<dyn StoreElement + Send + Sync> {
+        Arc::new(Self {
+            store_id: self.store_id,
+            id: self.id,
+            config: self.config.clone(),
+            backends: self.backends.clone(),
+        })
+    }
+
+    fn backend_name(&self) -> &[u8] {
+        // TODO: make into an Option.
+        &[]
+    }
+
+    fn backend_vaults(&self) -> Result<Cow<'_, [Bytes]>, CredentialParserError> {
+        // TODO: make into an Option.
+        Ok(Cow::Borrowed(&[]))
+    }
+
+    fn needs_authentication(&self) -> Option<bool> {
+        Some(false)
+    }
+
+    fn authentication_metadata(&self) -> Option<StoreAuthenticationMetadata> {
+        None
+    }
+
+    fn authenticate(
+        &self,
+        _kind: Bytes,
+        _message: Option<Bytes>,
+    ) -> Result<(Option<Bytes>, bool), protocol::Error> {
+        Err(ResponseCode::NotSupported.into())
+    }
+
+    fn update(
+        self: Arc<Self>,
+        _meta: Option<&BTreeMap<Bytes, Value>>,
+        _body: Option<&dyn Any>,
+    ) -> Result<(), protocol::Error> {
+        Err(ResponseCode::NotSupported.into())
+    }
+
+    fn delete(&self) -> Result<(), protocol::Error> {
+        Err(ResponseCode::NotSupported.into())
+    }
+
+    fn meta(&self) -> Option<Cow<'_, BTreeMap<Bytes, Value>>> {
+        None
+    }
+
+    fn body(&self) -> Result<Option<Box<dyn Any + 'static>>, protocol::Error> {
+        Ok(None)
+    }
+
+    fn search(
+        self: Arc<Self>,
+        _kind: Option<Bytes>,
+        _pattern: Option<&(dyn Any + 'static)>,
+        _recurse: StoreSearchRecursionLevel,
+    ) -> Result<
+        Box<dyn Iterator<Item = Arc<dyn StoreElement + Send + Sync>> + Send + Sync>,
+        protocol::Error,
+    > {
+        Err(ResponseCode::NotSupported.into())
+    }
+
+    fn create(
+        self: Arc<Self>,
+        _path: Option<Bytes>,
+        _kind: &str,
+        _meta: Option<&BTreeMap<Bytes, Value>>,
+        _body: Option<&(dyn Any + 'static)>,
+    ) -> Result<Arc<dyn StoreElement + Send + Sync>, protocol::Error> {
+        let logger = self.config().logger();
+        trace!(logger, "server: refusing to create an object at top level");
+        Err(ResponseCode::NotSupported.into())
+    }
+
+    fn contents(
+        &self,
+    ) -> Result<
+        Option<Box<dyn Iterator<Item = Arc<dyn StoreElementEntry + Send + Sync>> + Send + Sync>>,
+        protocol::Error,
+    > {
+        let backends = self.backends.lock().unwrap();
+        Ok(Some(Box::new(StoreElementEntryIterator::new(
+            backends
+                .iter()
+                .map(|(name, backend)| {
+                    let e: Arc<dyn StoreElementEntry + Send + Sync> =
+                        Arc::new(PlainStoreElementEntry {
+                            store_id: self.store_id,
+                            path: format_bytes!(b"/{}/", name.as_ref()).into(),
+                            kind: Bytes::from(b"directory" as &[u8]),
+                            auth: backend.needs_authentication(),
+                            auth_meta: backend.authentication_metadata(),
+                        });
+                    e
+                })
+                .collect(),
+        ))))
+    }
+}
+
+pub struct CredentialBackendStoreElement<T: CredentialBackendHandle> {
+    store_id: StoreID,
+    id: StoreSelectorID,
+    path: Bytes,
+    parent: Arc<T>,
+}
+
+impl<T: CredentialBackendHandle> StoreElement for CredentialBackendStoreElement<T> {
+    fn store_id(&self) -> StoreID {
+        self.store_id
+    }
+
+    fn id(&self) -> StoreSelectorID {
+        self.id
+    }
+
+    fn path(&self) -> Bytes {
+        self.path.clone()
+    }
+
+    fn is_directory(&self) -> bool {
+        self.path.ends_with(b"/")
+    }
+
+    fn kind(&self) -> &[u8] {
+        if StoreElement::is_directory(self) {
+            b"directory"
+        } else {
+            b"credential"
+        }
+    }
+
+    fn contents(
+        &self,
+    ) -> Result<
+        Option<Box<dyn Iterator<Item = Arc<dyn StoreElementEntry + Send + Sync>> + Send + Sync>>,
+        protocol::Error,
+    > {
+        if !StoreElement::is_directory(self) {
+            return Ok(None);
+        }
+        self.parent.clone().contents()
+    }
+
+    fn needs_authentication(&self) -> Option<bool> {
+        self.parent.needs_authentication()
+    }
+
+    fn authentication_metadata(&self) -> Option<StoreAuthenticationMetadata> {
+        self.parent.authentication_metadata()
+    }
+
+    fn authenticate(
+        &self,
+        kind: Bytes,
+        message: Option<Bytes>,
+    ) -> Result<(Option<Bytes>, bool), protocol::Error> {
+        self.parent.authenticate(kind, message)
+    }
+
+    fn update(
+        self: Arc<Self>,
+        meta: Option<&BTreeMap<Bytes, Value>>,
+        body: Option<&dyn Any>,
+    ) -> Result<(), protocol::Error> {
+        self.parent.clone().update(meta, body)
+    }
+
+    fn delete(&self) -> Result<(), protocol::Error> {
+        self.parent.delete()
+    }
+
+    fn meta(&self) -> Option<Cow<'_, BTreeMap<Bytes, Value>>> {
+        None
+    }
+
+    fn body(&self) -> Result<Option<Box<dyn Any + 'static>>, protocol::Error> {
+        self.parent.body()
+    }
+
+    fn search(
+        self: Arc<Self>,
+        kind: Option<Bytes>,
+        pattern: Option<&(dyn Any + 'static)>,
+        recurse: StoreSearchRecursionLevel,
+    ) -> Result<
+        Box<dyn Iterator<Item = Arc<dyn StoreElement + Send + Sync>> + Send + Sync>,
+        protocol::Error,
+    > {
+        self.parent.clone().search(kind, pattern, recurse)
+    }
+
+    fn create(
+        self: Arc<Self>,
+        path: Option<Bytes>,
+        kind: &str,
+        meta: Option<&BTreeMap<Bytes, Value>>,
+        body: Option<&dyn Any>,
+    ) -> Result<Arc<dyn StoreElement + Send + Sync>, protocol::Error> {
+        self.parent.clone().create(path, kind, meta, body)
+    }
+}
+
+pub trait CredentialVault: StoreElement {
+    fn name(&self) -> &[u8];
+    fn search(
+        self: Arc<Self>,
+        kind: Option<Bytes>,
+        pattern: Option<&(dyn Any + 'static)>,
+        recurse: StoreSearchRecursionLevel,
+    ) -> Result<
+        Box<dyn Iterator<Item = Arc<dyn StoreElement + Send + Sync>> + Send + Sync>,
+        protocol::Error,
+    >;
+    fn to_handle(self: Arc<Self>) -> Arc<dyn CredentialBackendHandle + Send + Sync>;
+}
+
+#[derive(Debug, Eq, PartialEq, Ord, PartialOrd)]
+pub enum CredentialPathComponentType {
+    Top,
+    Backend,
+    Vault,
+    VaultDirectory,
+    Entry,
+}
+
+impl CredentialPathComponentType {
+    pub fn from_path(path: Bytes) -> Option<Self> {
+        if !path.starts_with(b"/") {
+            return None;
+        }
+        let len = path.iter().cloned().filter(|x| *x == b'/').count();
+        Self::from_component_data(len + 1, path.ends_with(b"/"))
+    }
+
+    fn from_path_components<T: AsRef<[u8]>>(components: &[T]) -> Option<Self> {
+        if components.len() < 2 || !components[0].as_ref().is_empty() {
+            // This should never occur.
+            return None;
+        }
+        Self::from_component_data(
+            components.len(),
+            components[components.len() - 1].as_ref().is_empty(),
+        )
+    }
+
+    fn from_component_data(len: usize, last_is_empty: bool) -> Option<Self> {
+        match (len, last_is_empty) {
+            // This is the top-level item.
+            (2, true) => Some(CredentialPathComponentType::Top),
+            // This is trying to use a credential backend as a file.
+            (2, false) => None,
+            // This is a credential backend.
+            (3, true) => Some(CredentialPathComponentType::Backend),
+            // This is trying to use a credential vault as a file.
+            (3, false) => None,
+            // This is a credential vault.
+            (4, true) => Some(CredentialPathComponentType::Vault),
+            // This is a credential vault directory.
+            (n, true) if n >= 5 => Some(CredentialPathComponentType::VaultDirectory),
+            // This is a credential vault entry.
+            (n, false) if n >= 4 => Some(CredentialPathComponentType::Entry),
+            _ => None,
+        }
+    }
+}
+
+type CredentialElements =
+    Arc<RwLock<BTreeMap<StoreSelectorID, Arc<dyn CredentialBackendHandle + Send + Sync>>>>;
+
+pub struct CredentialStore {
+    id: StoreID,
+    config: Arc<Config>,
+    next_id: Arc<AtomicU32>,
+    elems: CredentialElements,
+    backends: Arc<Mutex<BTreeMap<Bytes, Arc<dyn CredentialBackend + Send + Sync>>>>,
+}
+
+impl CredentialStore {
+    pub fn new(id: StoreID, config: Arc<Config>) -> Self {
+        Self {
+            id,
+            elems: Arc::new(RwLock::new(BTreeMap::new())),
+            next_id: Arc::new(AtomicU32::new(0)),
+            config,
+            backends: Arc::new(Mutex::new(BTreeMap::new())),
+        }
+    }
+
+    fn create_all_backends(&self) {
+        if let Ok(backends) = self.config.credential_backends_as_map() {
+            for (name, _) in backends {
+                self.create_backend_from_name(name.as_bytes());
+            }
+        }
+    }
+
+    fn create_backend_from_name(
+        &self,
+        name: &[u8],
+    ) -> Option<Arc<dyn CredentialBackend + Send + Sync>> {
+        let mut data = self.backends.lock().unwrap();
+        if let Some(backend) = data.get(name) {
+            return Some(backend.clone());
+        }
+        let backends = self.config.credential_backends_as_map().ok()?;
+        let backend = std::str::from_utf8(name).ok().and_then(|c| backends.get(c));
+        let obj: Option<Arc<dyn CredentialBackend + Send + Sync>> =
+            match backend.as_ref().map(|b| &b.kind) {
+                Some(CredentialBackendType::Git { command }) => {
+                    Some(Arc::new(git::GitCredentialBackend::new(
+                        self.config.clone(),
+                        self.elems.clone(),
+                        self.next_id.clone(),
+                        Bytes::copy_from_slice(name),
+                        &command,
+                    )))
+                }
+                Some(CredentialBackendType::Memory { token }) => {
+                    Some(Arc::new(memory::MemoryCredentialBackend::new(
+                        self.config.clone(),
+                        self.elems.clone(),
+                        self.next_id.clone(),
+                        Bytes::copy_from_slice(name),
+                        token.as_deref(),
+                    )))
+                }
+                _ => None,
+            };
+        let obj = obj?;
+        data.insert(Bytes::copy_from_slice(name), obj.clone());
+        Some(obj)
+    }
+}
+
+impl Store for CredentialStore {
+    fn id(&self) -> StoreID {
+        self.id
+    }
+
+    fn acquire(
+        &self,
+        path: Bytes,
+    ) -> Result<Option<Arc<dyn StoreElement + Send + Sync>>, protocol::Error> {
+        let components: Vec<_> = match StorePath::new(path.clone()) {
+            Some(p) => p.components(),
+            None => return Err(ResponseCode::NotFound.into()),
+        };
+        if components.len() < 2 || !components[0].is_empty() {
+            // This should never occur.
+            return Err(ResponseCode::NotFound.into());
+        }
+        let backend = components
+            .get(1)
+            .and_then(|c| self.create_backend_from_name(c));
+        let resp: Result<Option<Arc<dyn CredentialBackendHandle + Send + Sync>>, _> =
+            match CredentialPathComponentType::from_path_components(&components) {
+                Some(CredentialPathComponentType::Top) => {
+                    self.create_all_backends();
+                    Ok(Some(Arc::new(TopLevelCredentialBackendHandle {
+                        store_id: self.id,
+                        id: StoreSelectorID(self.next_id.fetch_add(1, Ordering::AcqRel)),
+                        config: self.config.clone(),
+                        backends: self.backends.clone(),
+                    })))
+                }
+                Some(CredentialPathComponentType::Backend) => match backend {
+                    Some(b) => Ok(Some(b.to_handle(self.id()))),
+                    None => Err(ResponseCode::NotFound.into()),
+                },
+                Some(CredentialPathComponentType::Vault) => {
+                    let b = backend.ok_or(protocol::Error::from(ResponseCode::NotFound))?;
+                    let vault = components
+                        .get(2)
+                        .and_then(|v| b.vault_by_name(self.id, v).ok()?)
+                        .ok_or(protocol::Error::from(ResponseCode::NotFound))?;
+                    Ok(Some(vault.to_handle()))
+                }
+                Some(CredentialPathComponentType::VaultDirectory)
+                | Some(CredentialPathComponentType::Entry) => {
+                    let b = backend.ok_or(protocol::Error::from(ResponseCode::NotFound))?;
+                    b.acquire_at_path(self.id, path.clone())
+                        .map_err(|e| match e {
+                            CredentialParserError::Unlistable => ResponseCode::Unlistable.into(),
+                            CredentialParserError::Unauthenticated => {
+                                ResponseCode::NeedsAuthentication.into()
+                            }
+                            CredentialParserError::NoSuchHandle => ResponseCode::NotFound.into(),
+                            _ => ResponseCode::InternalError.into(),
+                        })
+                }
+                None => Err(ResponseCode::NotFound.into()),
+            };
+        if let Ok(Some(ref item)) = resp {
+            self.elems.write().unwrap().insert(item.id(), item.clone());
+        }
+        resp.map(|op| op.map(|el| el.to_store_element()))
+    }
+
+    fn get(&self, id: StoreSelectorID) -> Option<Arc<dyn StoreElement + Send + Sync>> {
+        self.elems
+            .read()
+            .unwrap()
+            .get(&id)
+            .map(|handle| handle.clone().to_store_element())
+    }
+
+    fn close(&self, id: StoreSelectorID) -> Result<(), protocol::Error> {
+        match self.elems.write().unwrap().remove(&id) {
+            Some(_) => Ok(()),
+            None => Err(ResponseCode::NotFound.into()),
+        }
+    }
+
+    fn delete(&self, id: StoreSelectorID) -> Result<(), protocol::Error> {
+        let resp = match self.elems.read().unwrap().get(&id) {
+            Some(handle) => handle.delete(),
+            None => Err(ResponseCode::NotFound.into()),
+        };
+        let _ = self.close(id);
+        resp
+    }
+
+    fn search(
+        &self,
+        id: StoreSelectorID,
+        kind: Option<Bytes>,
+        pattern: Option<&(dyn Any + 'static)>,
+        recurse: StoreSearchRecursionLevel,
+    ) -> Result<
+        Box<dyn Iterator<Item = Arc<dyn StoreElement + Send + Sync>> + Send + Sync>,
+        protocol::Error,
+    > {
+        match self.elems.read().unwrap().get(&id) {
+            Some(handle) => handle.clone().search(kind, pattern, recurse),
+            None => Err(ResponseCode::NotFound.into()),
+        }
+    }
+
+    fn create(
+        &self,
+        path: Bytes,
+        kind: &str,
+        meta: Option<&BTreeMap<Bytes, Value>>,
+        body: Option<&dyn Any>,
+    ) -> Result<Arc<dyn StoreElement + Send + Sync>, protocol::Error> {
+        match (path.ends_with(b"/"), kind) {
+            (true, "directory") => {
+                let mut components = StorePath::new(path.clone())
+                    .ok_or(ResponseCode::Invalid)?
+                    .components();
+                if components.len() < 3 {
+                    return Err(ResponseCode::Invalid.into());
+                }
+                components.remove(components.len() - 2);
+                let newpath = StorePath::from_components(&components)
+                    .ok_or(ResponseCode::Invalid)?
+                    .into_inner();
+                let handle = self
+                    .acquire(newpath)?
+                    .ok_or(protocol::Error::from(ResponseCode::NotFound))?;
+                handle.create(Some(path), kind, meta, body)
+            }
+            // We're creating an element at a location that's specified by the backend.
+            (true, _) => {
+                let handle = self
+                    .acquire(path)?
+                    .ok_or(protocol::Error::from(ResponseCode::NotFound))?;
+                handle.create(None, kind, meta, body)
+            }
+            _ => Err(ResponseCode::NotSupported.into()),
+        }
+    }
+}

--- a/lawn/src/store/credential.rs
+++ b/lawn/src/store/credential.rs
@@ -17,6 +17,7 @@ use std::sync::{Arc, Mutex, RwLock};
 
 pub mod git;
 pub mod helpers;
+pub mod memory;
 
 pub trait CredentialBackend {
     fn name(&self) -> &[u8];

--- a/lawn/src/store/credential/git.rs
+++ b/lawn/src/store/credential/git.rs
@@ -1,0 +1,241 @@
+use super::helpers::{BoxedCredentialBackendHandleIterator, CommandCredentialBackend};
+use super::{CredentialBackendHandle, CredentialElements};
+use crate::config::{self, Config};
+use crate::credential::protocol::git::GitProtocolHandler;
+use crate::credential::{Credential, CredentialParserError, CredentialRequest};
+use crate::store::{StoreAuthenticationMetadata, StorePath};
+use bytes::Bytes;
+use lawn_protocol::protocol::{self, ResponseCode, StoreSelectorID};
+use std::any::Any;
+use std::borrow::Cow;
+use std::process::Stdio;
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::{Arc, Mutex};
+
+pub struct GitCredentialBackend {
+    config: Arc<Config>,
+    name: Bytes,
+    command: String,
+    next_id: Arc<AtomicU32>,
+    elems: CredentialElements,
+}
+
+impl GitCredentialBackend {
+    pub fn new(
+        config: Arc<Config>,
+        elems: CredentialElements,
+        ids: Arc<AtomicU32>,
+        name: Bytes,
+        command: &str,
+    ) -> Self {
+        Self {
+            config,
+            name,
+            command: command.to_owned(),
+            next_id: ids,
+            elems,
+        }
+    }
+
+    fn create_command(
+        &self,
+        subcommand: Bytes,
+    ) -> Result<std::process::Command, crate::error::Error> {
+        let args = &[subcommand];
+        let ctx = self.config.template_context(None, Some(args));
+        Ok(config::Command::new_simple(&self.command, &ctx)?.run_std_command())
+    }
+
+    fn do_write_credential_op(
+        &self,
+        command: &'static str,
+        req: &Credential,
+    ) -> Result<Bytes, CredentialParserError> {
+        let mut cmd = self
+            .create_command(Bytes::from(command))
+            .map_err(|_| CredentialParserError::SpawnError)?;
+        cmd.stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::inherit());
+        let mut child = cmd.spawn()?;
+        let (stdin, stdout) = (child.stdin.take().unwrap(), child.stdout.take().unwrap());
+        let proto = GitProtocolHandler::new(
+            Arc::new(Mutex::new(stdout)),
+            Arc::new(Mutex::new(stdin)),
+            None,
+            None,
+            None,
+        );
+        proto.clone().send_approve_reject_request(req)?;
+        proto.clone().close_writer();
+        let _ = child.wait();
+        let components: &[&[u8]] = &[b"", self.backend_name(), b"-", &req.id];
+        let path = StorePath::from_components(components).unwrap().into_inner();
+        Ok(path)
+    }
+}
+
+impl CommandCredentialBackend for GitCredentialBackend {
+    type Backend = Arc<Self>;
+
+    fn config(self: Arc<Self>) -> Arc<Config> {
+        self.config.clone()
+    }
+
+    fn backend_name(&self) -> &[u8] {
+        self.name.as_ref()
+    }
+
+    fn backend_type(&self) -> &str {
+        "git"
+    }
+
+    fn needs_authentication(&self) -> bool {
+        false
+    }
+
+    fn authentication_metadata(&self) -> Option<StoreAuthenticationMetadata> {
+        None
+    }
+
+    fn authenticate(
+        &self,
+        _kind: Bytes,
+        _message: Option<Bytes>,
+    ) -> Result<(Option<Bytes>, bool), protocol::Error> {
+        Err(ResponseCode::NotSupported.into())
+    }
+
+    fn list_vaults(&self) -> Result<Cow<'_, [Bytes]>, CredentialParserError> {
+        Ok(Cow::Owned([Bytes::from(b"-" as &[u8])].into()))
+    }
+
+    fn next_id(self: Arc<Self>) -> StoreSelectorID {
+        StoreSelectorID(self.next_id.fetch_add(1, Ordering::AcqRel))
+    }
+
+    fn insert_handle(
+        self: Arc<Self>,
+        id: StoreSelectorID,
+        handle: Arc<dyn CredentialBackendHandle + Send + Sync>,
+    ) {
+        self.elems.write().unwrap().insert(id, handle.clone());
+    }
+
+    fn get_handle(
+        self: Arc<Self>,
+        id: StoreSelectorID,
+    ) -> Option<Arc<dyn CredentialBackendHandle + Send + Sync>> {
+        self.elems.read().unwrap().get(&id).cloned()
+    }
+
+    fn search_credential(
+        self: Arc<Self>,
+        _id: StoreSelectorID,
+        req: &CredentialRequest,
+    ) -> Result<Option<(Credential, Bytes)>, CredentialParserError> {
+        let logger = self.config.logger();
+        let mut cmd = self
+            .create_command(Bytes::from("fill"))
+            .map_err(|_| CredentialParserError::SpawnError)?;
+        cmd.stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::inherit());
+        let mut child = match cmd.spawn() {
+            Ok(child) => child,
+            Err(e) => return Err(e.into()),
+        };
+        let (stdin, stdout) = (child.stdin.take().unwrap(), child.stdout.take().unwrap());
+        let proto = GitProtocolHandler::new(
+            Arc::new(Mutex::new(stdout)),
+            Arc::new(Mutex::new(stdin)),
+            None,
+            None,
+            None,
+        );
+        match proto.clone().send_fill_request(req) {
+            Ok(()) => (),
+            Err(e) => {
+                trace!(
+                    logger,
+                    "server: git credential: read: send fill request failed: {:?}",
+                    e
+                );
+                return Err(e);
+            }
+        }
+        proto.clone().close_writer();
+        let r = proto.parse_fill_response();
+        let _ = child.wait();
+        match r {
+            Ok(Some(cred)) => {
+                let id = cred.id();
+                match StorePath::from_components::<&[u8]>(&[b"", self.backend_name(), b"-", &id]) {
+                    Some(path) => Ok(Some((cred, path.into_inner()))),
+                    None => Ok(None),
+                }
+            }
+            Ok(None) => Ok(None),
+            Err(e) => {
+                trace!(
+                    logger,
+                    "server: git credential: read: parsing fill response failed: {:?}",
+                    e
+                );
+                Err(e)
+            }
+        }
+    }
+
+    fn write_credential(
+        self: Arc<Self>,
+        _id: StoreSelectorID,
+        cred: &Credential,
+        _overwrite: bool,
+        _create: bool,
+    ) -> Result<Bytes, CredentialParserError> {
+        self.do_write_credential_op("approve", cred)
+    }
+
+    fn delete_credential(
+        self: Arc<Self>,
+        _id: StoreSelectorID,
+        cred: &Credential,
+    ) -> Result<(), CredentialParserError> {
+        self.do_write_credential_op("reject", cred)?;
+        Ok(())
+    }
+
+    fn delete_credential_by_id(
+        self: Arc<Self>,
+        _id: StoreSelectorID,
+    ) -> Result<(), CredentialParserError> {
+        Err(CredentialParserError::Unlistable)
+    }
+
+    fn listable(&self) -> bool {
+        false
+    }
+
+    fn list_entries(
+        self: Arc<Self>,
+        _id: StoreSelectorID,
+    ) -> Result<Option<BoxedCredentialBackendHandleIterator>, protocol::Error> {
+        Err(ResponseCode::Unlistable.into())
+    }
+
+    fn create_directory(self: Arc<Self>, _path: Bytes) -> Result<(), protocol::Error> {
+        Err(ResponseCode::NotSupported.into())
+    }
+
+    fn exists(self: Arc<Self>, _path: Bytes) -> Result<bool, CredentialParserError> {
+        Err(CredentialParserError::Unlistable)
+    }
+
+    fn read_body(
+        self: Arc<Self>,
+        _id: StoreSelectorID,
+    ) -> Result<Option<Box<dyn Any + 'static>>, protocol::Error> {
+        Err(ResponseCode::Unlistable.into())
+    }
+}

--- a/lawn/src/store/credential/git.rs
+++ b/lawn/src/store/credential/git.rs
@@ -41,7 +41,7 @@ impl GitCredentialBackend {
         &self,
         subcommand: Bytes,
     ) -> Result<std::process::Command, crate::error::Error> {
-        let args = &[subcommand];
+        let args = Arc::new([subcommand]);
         let ctx = self.config.template_context(None, Some(args));
         Ok(config::Command::new_simple(&self.command, &ctx)?.run_std_command())
     }

--- a/lawn/src/store/credential/helpers.rs
+++ b/lawn/src/store/credential/helpers.rs
@@ -1,0 +1,734 @@
+use super::{
+    CredentialBackend, CredentialBackendHandle, CredentialBackendStoreElement,
+    CredentialPathComponentType, CredentialVault,
+};
+use crate::config::Config;
+use crate::credential::{Credential, CredentialParserError, CredentialRequest};
+use crate::store::{
+    StoreAuthenticationMetadata, StoreElement, StoreElementEntry, StoreElementEntryIterator,
+    StorePath,
+};
+use bytes::Bytes;
+use format_bytes::format_bytes;
+use lawn_protocol::protocol::{
+    self, CredentialStoreElement, CredentialStoreSearchElement, ResponseCode, StoreID,
+    StoreSearchRecursionLevel, StoreSelectorID,
+};
+use serde_cbor::Value;
+use std::any::Any;
+use std::borrow::Cow;
+use std::collections::BTreeMap;
+use std::convert::TryInto;
+use std::sync::{Arc, Mutex};
+
+pub struct CommandCredentialVault<
+    T: Send + Sync + 'static,
+    U: CommandCredentialBackend<Backend = T> + Sized + Send + Sync + 'static,
+> {
+    store_id: StoreID,
+    id: StoreSelectorID,
+    name: Bytes,
+    parent: Arc<U>,
+}
+
+impl<
+        T: Send + Sync + 'static,
+        U: CommandCredentialBackend<Backend = T> + Send + Sync + 'static,
+    > CredentialVault for CommandCredentialVault<T, U>
+{
+    fn name(&self) -> &[u8] {
+        self.name.as_ref()
+    }
+
+    fn search(
+        self: Arc<Self>,
+        kind: Option<Bytes>,
+        pattern: Option<&(dyn Any + 'static)>,
+        recurse: StoreSearchRecursionLevel,
+    ) -> Result<
+        Box<dyn Iterator<Item = Arc<dyn StoreElement + Send + Sync>> + Send + Sync>,
+        protocol::Error,
+    > {
+        self.to_handle().search(kind, pattern, recurse)
+    }
+
+    fn to_handle(self: Arc<Self>) -> Arc<dyn CredentialBackendHandle + Send + Sync> {
+        Arc::new(CommandCredentialBackendHandle {
+            store_id: self.store_id,
+            id: self.id,
+            path: StoreElement::path(self.as_ref()),
+            parent: Arc::clone(&self.parent),
+            credential: Mutex::new(None),
+        })
+    }
+}
+
+impl<T: Send + Sync, U: CommandCredentialBackend<Backend = T> + Sized + Send + Sync + ?Sized>
+    StoreElement for CommandCredentialVault<T, U>
+{
+    fn store_id(&self) -> StoreID {
+        self.store_id
+    }
+
+    fn id(&self) -> StoreSelectorID {
+        self.id
+    }
+
+    fn path(&self) -> Bytes {
+        StorePath::from_components::<&[u8]>(&[
+            b"",
+            self.parent.backend_name(),
+            self.name.as_ref(),
+            b"",
+        ])
+        .unwrap()
+        .into_inner()
+    }
+
+    fn kind(&self) -> &[u8] {
+        b"directory"
+    }
+
+    fn contents(
+        &self,
+    ) -> Result<
+        Option<Box<dyn Iterator<Item = Arc<dyn StoreElementEntry + Send + Sync>> + Send + Sync>>,
+        protocol::Error,
+    > {
+        let logger = self.parent.clone().config().logger();
+        trace!(
+            logger,
+            "server: {} backend: contents: vault",
+            self.parent.backend_type()
+        );
+        if !self.parent.listable() {
+            return Err(ResponseCode::Unlistable.into());
+        }
+        let items = match self.parent.clone().list_entries(self.id) {
+            Ok(Some(items)) => items.map(|item| item.to_store_element_entry()).collect(),
+            Ok(None) => return Ok(None),
+            Err(e) => return Err(e),
+        };
+        Ok(Some(Box::new(StoreElementEntryIterator::new(items))))
+    }
+
+    fn needs_authentication(&self) -> Option<bool> {
+        Some(self.parent.needs_authentication())
+    }
+
+    fn authentication_metadata(&self) -> Option<StoreAuthenticationMetadata> {
+        self.parent.authentication_metadata()
+    }
+
+    fn authenticate(
+        &self,
+        kind: Bytes,
+        message: Option<Bytes>,
+    ) -> Result<(Option<Bytes>, bool), protocol::Error> {
+        self.parent.authenticate(kind, message)
+    }
+
+    fn update(
+        self: Arc<Self>,
+        meta: Option<&BTreeMap<Bytes, Value>>,
+        body: Option<&(dyn Any + 'static)>,
+    ) -> Result<(), protocol::Error> {
+        self.to_handle().update(meta, body)
+    }
+
+    fn delete(&self) -> Result<(), protocol::Error> {
+        Err(ResponseCode::NotSupported.into())
+    }
+
+    fn meta(&self) -> Option<Cow<'_, BTreeMap<Bytes, Value>>> {
+        let mut map = BTreeMap::new();
+        map.insert(
+            Bytes::from(b"backend-type" as &'static [u8]),
+            Value::Text(self.parent.backend_type().into()),
+        );
+        Some(Cow::Owned(map))
+    }
+
+    fn body(&self) -> Result<Option<Box<dyn Any + 'static>>, protocol::Error> {
+        Err(ResponseCode::NotSupported.into())
+    }
+
+    fn search(
+        self: Arc<Self>,
+        kind: Option<Bytes>,
+        pattern: Option<&(dyn Any + 'static)>,
+        recurse: StoreSearchRecursionLevel,
+    ) -> Result<
+        Box<dyn Iterator<Item = Arc<dyn StoreElement + Send + Sync>> + Send + Sync>,
+        protocol::Error,
+    > {
+        self.to_handle().search(kind, pattern, recurse)
+    }
+
+    fn create(
+        self: Arc<Self>,
+        path: Option<Bytes>,
+        kind: &str,
+        meta: Option<&BTreeMap<Bytes, Value>>,
+        body: Option<&(dyn Any + 'static)>,
+    ) -> Result<Arc<dyn StoreElement + Send + Sync>, protocol::Error> {
+        self.to_handle().create(path, kind, meta, body)
+    }
+}
+
+pub struct CommandCredentialBackendHandle<
+    T: Send + Sync,
+    U: CommandCredentialBackend<Backend = T> + Send + Sync,
+> {
+    store_id: StoreID,
+    id: StoreSelectorID,
+    path: Bytes,
+    parent: Arc<U>,
+    credential: Mutex<Option<Credential>>,
+}
+
+impl<
+        T: Send + Sync + 'static,
+        U: CommandCredentialBackend<Backend = T> + Send + Sync + 'static,
+    > CommandCredentialBackendHandle<T, U>
+{
+    pub(super) fn new(store_id: StoreID, id: StoreSelectorID, path: Bytes, parent: Arc<U>) -> Self {
+        Self {
+            store_id,
+            id,
+            path,
+            parent,
+            credential: Mutex::new(None),
+        }
+    }
+
+    pub(super) fn new_with_credential(
+        store_id: StoreID,
+        id: StoreSelectorID,
+        path: Bytes,
+        parent: Arc<U>,
+        cred: Credential,
+    ) -> Self {
+        Self {
+            store_id,
+            id,
+            path,
+            parent,
+            credential: Mutex::new(Some(cred)),
+        }
+    }
+}
+
+impl<
+        T: Send + Sync + 'static,
+        U: CommandCredentialBackend<Backend = T> + Send + Sync + 'static,
+    > CredentialBackendHandle for CommandCredentialBackendHandle<T, U>
+{
+    fn config(&self) -> Arc<Config> {
+        self.parent.clone().config()
+    }
+
+    fn store_id(&self) -> StoreID {
+        self.store_id
+    }
+
+    fn id(&self) -> StoreSelectorID {
+        self.id
+    }
+
+    fn to_store_element_entry(self: Arc<Self>) -> Arc<dyn StoreElementEntry + Send + Sync> {
+        Arc::new(CredentialBackendStoreElement {
+            store_id: self.store_id,
+            id: self.id,
+            path: self.path.clone(),
+            parent: self,
+        })
+    }
+
+    fn to_store_element(self: Arc<Self>) -> Arc<dyn StoreElement + Send + Sync> {
+        Arc::new(CredentialBackendStoreElement {
+            store_id: self.store_id,
+            id: self.id,
+            path: self.path.clone(),
+            parent: self,
+        })
+    }
+
+    fn backend_name(&self) -> &[u8] {
+        self.parent.backend_name()
+    }
+
+    fn backend_vaults(&self) -> Result<Cow<'_, [Bytes]>, CredentialParserError> {
+        self.parent.list_vaults()
+    }
+
+    fn needs_authentication(&self) -> Option<bool> {
+        Some(self.parent.needs_authentication())
+    }
+
+    fn authentication_metadata(&self) -> Option<StoreAuthenticationMetadata> {
+        self.parent.authentication_metadata()
+    }
+
+    fn authenticate(
+        &self,
+        kind: Bytes,
+        message: Option<Bytes>,
+    ) -> Result<(Option<Bytes>, bool), protocol::Error> {
+        self.parent.authenticate(kind, message)
+    }
+
+    fn update(
+        self: Arc<Self>,
+        _meta: Option<&BTreeMap<Bytes, Value>>,
+        body: Option<&dyn Any>,
+    ) -> Result<(), protocol::Error> {
+        let logger = self.parent.clone().config().logger();
+        match CredentialPathComponentType::from_path(self.path.clone()) {
+            Some(CredentialPathComponentType::Entry) => (),
+            _ => return Err(ResponseCode::NotSupported.into()),
+        }
+        let c: &CredentialStoreElement =
+            match body.and_then(|p| p.downcast_ref::<CredentialStoreElement>()) {
+                Some(p) => p,
+                None => return Err(ResponseCode::NotSupported.into()),
+            };
+        let c: Credential = c.try_into().map_err(|e| {
+            trace!(logger, "server: failed to convert credential: {}", e);
+            protocol::Error::from(ResponseCode::Invalid)
+        })?;
+        // TODO: use a better error code.
+        self.parent
+            .clone()
+            .write_credential(self.id(), &c, true, false)
+            .map_err(|e| match e {
+                CredentialParserError::Unauthenticated => ResponseCode::NeedsAuthentication.into(),
+                e => {
+                    trace!(
+                        logger,
+                        "server: {} credential: update: error: {}",
+                        self.parent.backend_type(),
+                        e
+                    );
+                    protocol::Error::from(ResponseCode::InternalError)
+                }
+            })?;
+        let mut g = self.credential.lock().unwrap();
+        *g = Some(c);
+        Ok(())
+    }
+
+    fn delete(&self) -> Result<(), protocol::Error> {
+        let g = self.credential.lock().unwrap();
+        match &*g {
+            Some(c) => self
+                .parent
+                .clone()
+                .delete_credential(self.id, c)
+                .map_err(|e| {
+                    let logger = self.parent.clone().config().logger();
+                    trace!(
+                        logger,
+                        "server: {} credential: delete: error: {}",
+                        self.parent.backend_type(),
+                        e
+                    );
+                    protocol::Error::from(ResponseCode::InternalError)
+                }),
+            None => self
+                .parent
+                .clone()
+                .delete_credential_by_id(self.id)
+                .map_err(|e| match e {
+                    CredentialParserError::Unlistable => {
+                        protocol::Error::from(ResponseCode::Unlistable)
+                    }
+                    e => {
+                        let logger = self.parent.clone().config().logger();
+                        trace!(
+                            logger,
+                            "server: {} credential: delete by ID: error: {}",
+                            self.parent.backend_type(),
+                            e
+                        );
+                        protocol::Error::from(ResponseCode::InternalError)
+                    }
+                }),
+        }
+    }
+
+    fn meta(&self) -> Option<Cow<'_, BTreeMap<Bytes, Value>>> {
+        None
+    }
+
+    fn body(&self) -> Result<Option<Box<dyn Any + 'static>>, protocol::Error> {
+        match self.credential.lock().unwrap().as_ref() {
+            Some(c) => {
+                let cse: CredentialStoreElement = c.into();
+                Ok(Some(Box::new(cse)))
+            }
+            None => self.parent.clone().read_body(self.id),
+        }
+    }
+
+    fn search(
+        self: Arc<Self>,
+        kind: Option<Bytes>,
+        pattern: Option<&(dyn Any + 'static)>,
+        recurse: StoreSearchRecursionLevel,
+    ) -> Result<
+        Box<dyn Iterator<Item = Arc<dyn StoreElement + Send + Sync>> + Send + Sync>,
+        protocol::Error,
+    > {
+        let logger = self.parent.clone().config().logger();
+        match kind.as_deref() {
+            Some(b"credential") | None => (),
+            _ => return Ok(Box::new(Vec::new().into_iter())),
+        }
+        let g = self.credential.lock().unwrap();
+        let csse: Option<&CredentialStoreSearchElement> = match (
+            pattern.map(|p| p.downcast_ref::<CredentialStoreSearchElement>()),
+            g.as_ref(),
+        ) {
+            (Some(Some(p)), _) => Some(p),
+            (None, Some(_)) => None,
+            _ => return Err(ResponseCode::NotSupported.into()),
+        };
+        if g.is_some() {
+            return Ok(Box::new(vec![self.clone().to_store_element()].into_iter()));
+        }
+        match recurse {
+            StoreSearchRecursionLevel::Boolean(true) => (),
+            StoreSearchRecursionLevel::Boolean(false) => return Ok(Box::new(vec![].into_iter())),
+            _ => return Err(ResponseCode::NotSupported.into()),
+        }
+        std::mem::drop(g);
+        let req = match csse.and_then(|req| req.try_into().ok()) {
+            Some(req) => req,
+            None => return Ok(Box::new(vec![].into_iter())),
+        };
+        trace!(logger, "server: credential: search: {:?}", req);
+        match self.parent.clone().search_credential(self.id(), &req) {
+            Ok(Some((cred, path))) => {
+                let elem = Arc::new(CommandCredentialBackendHandle {
+                    store_id: self.store_id,
+                    id: self.parent.clone().next_id(),
+                    path,
+                    credential: Mutex::new(Some(cred)),
+                    parent: self.parent.clone(),
+                });
+                self.parent.clone().insert_handle(elem.id, elem.clone());
+                Ok(Box::new(vec![elem.to_store_element()].into_iter()))
+            }
+            Ok(None) => {
+                trace!(logger, "server: credential: no credential returned");
+                Ok(Box::new(vec![].into_iter()))
+            }
+            Err(CredentialParserError::Unauthenticated) => {
+                trace!(
+                    logger,
+                    "server: credential: unauthenticated reading credential",
+                );
+                Err(ResponseCode::NeedsAuthentication.into())
+            }
+            Err(e) => {
+                trace!(
+                    logger,
+                    "server: credential: error reading credential: {:?}",
+                    e
+                );
+                Ok(Box::new(vec![].into_iter()))
+            }
+        }
+    }
+
+    fn create(
+        self: Arc<Self>,
+        path: Option<Bytes>,
+        kind: &str,
+        _meta: Option<&BTreeMap<Bytes, Value>>,
+        body: Option<&(dyn Any + 'static)>,
+    ) -> Result<Arc<dyn StoreElement + Send + Sync>, protocol::Error> {
+        let logger = self.parent.clone().config().logger();
+        trace!(
+            logger,
+            "server: creating element of type {} with path {:?}",
+            kind,
+            path
+        );
+        if let Some(path) = path.clone() {
+            if kind != "directory" {
+                trace!(
+                    logger,
+                    "server: attempting to create unsupported object {} by name",
+                    kind
+                );
+                return Err(ResponseCode::NotSupported.into());
+            }
+            trace!(logger, "server: creating directory");
+            match self.parent.clone().create_directory(path.clone()) {
+                Ok(()) => {
+                    let handle = Arc::new(CommandCredentialBackendHandle {
+                        store_id: self.store_id,
+                        id: self.parent.clone().next_id(),
+                        path,
+                        credential: Mutex::new(None),
+                        parent: self.parent.clone(),
+                    });
+                    self.parent.clone().insert_handle(handle.id, handle.clone());
+                    return Ok(handle.to_store_element());
+                }
+                Err(e) => return Err(e),
+            }
+        }
+        if kind != "credential" {
+            trace!(
+                logger,
+                "server: attempting to create unsupported non-credential object {}",
+                kind
+            );
+            return Err(ResponseCode::NotSupported.into());
+        }
+        trace!(logger, "server: creating credential");
+        let c: &CredentialStoreElement =
+            match body.and_then(|p| p.downcast_ref::<CredentialStoreElement>()) {
+                Some(p) => p,
+                None => return Err(ResponseCode::NotSupported.into()),
+            };
+        let mut c: Credential = c.try_into().map_err(|e| {
+            trace!(logger, "server: failed to convert credential: {}", e);
+            protocol::Error::from(ResponseCode::Invalid)
+        })?;
+        c.id = c.generate_id();
+        // TODO: use a better error code.
+        let path = self
+            .parent
+            .clone()
+            .write_credential(self.id(), &c, false, true)
+            .map_err(|e| match e {
+                CredentialParserError::Unauthenticated => ResponseCode::NeedsAuthentication.into(),
+                e => {
+                    let logger = self.parent.clone().config().logger();
+                    trace!(
+                        logger,
+                        "server: {} credential: update: error: {}",
+                        self.parent.backend_type(),
+                        e
+                    );
+                    protocol::Error::from(ResponseCode::InternalError)
+                }
+            })?;
+        let handle = Arc::new(CommandCredentialBackendHandle {
+            store_id: self.store_id,
+            id: self.parent.clone().next_id(),
+            path,
+            credential: Mutex::new(Some(c)),
+            parent: self.parent.clone(),
+        });
+        self.parent.clone().insert_handle(handle.id, handle.clone());
+        Ok(handle.to_store_element())
+    }
+
+    fn contents(
+        &self,
+    ) -> Result<
+        Option<Box<dyn Iterator<Item = Arc<dyn StoreElementEntry + Send + Sync>> + Send + Sync>>,
+        protocol::Error,
+    > {
+        let logger = self.parent.clone().config().logger();
+        let kind = CredentialPathComponentType::from_path(self.path.clone())
+            .ok_or(ResponseCode::InternalError)?;
+        trace!(
+            logger,
+            "server: {} backend: contents: list contents: {:?}",
+            self.parent.backend_type(),
+            kind,
+        );
+        if kind == CredentialPathComponentType::Backend {
+            match self.parent.clone().list_vaults() {
+                Ok(vaults) => {
+                    let store_id = self.store_id;
+                    let parent = self.parent.clone();
+                    let backend = self.backend_name();
+                    let v = vaults
+                        .iter()
+                        .map(|v| {
+                            let path = format_bytes!(b"/{}/{}/", backend, v.as_ref());
+                            let handle = Arc::new(CommandCredentialBackendHandle {
+                                store_id,
+                                id: parent.clone().next_id(),
+                                path: path.into(),
+                                credential: Mutex::new(None),
+                                parent: parent.clone(),
+                            });
+                            parent.clone().insert_handle(handle.id, handle.clone());
+                            handle.to_store_element_entry()
+                        })
+                        .collect::<Vec<_>>();
+                    Ok(Some(Box::new(v.into_iter())))
+                }
+                Err(CredentialParserError::Unauthenticated) => {
+                    Err(ResponseCode::NeedsAuthentication.into())
+                }
+                Err(_) => Err(ResponseCode::InternalError.into()),
+            }
+        } else {
+            match self.parent.clone().list_entries(self.id) {
+                Ok(Some(b)) => {
+                    let v = b.map(|h| h.to_store_element_entry()).collect::<Vec<_>>();
+                    Ok(Some(Box::new(v.into_iter())))
+                }
+                Ok(None) => Ok(None),
+                Err(e) => Err(e),
+            }
+        }
+    }
+}
+
+pub(super) type BoxedCredentialBackendHandleIterator =
+    Box<dyn Iterator<Item = Arc<dyn CredentialBackendHandle + Send + Sync>> + Send + Sync>;
+
+pub trait CommandCredentialBackend {
+    type Backend: Send + Sync;
+
+    fn config(self: Arc<Self>) -> Arc<Config>;
+    fn backend_name(&self) -> &[u8];
+    fn backend_type(&self) -> &str;
+    fn list_vaults(&self) -> Result<Cow<'_, [Bytes]>, CredentialParserError>;
+    fn listable(&self) -> bool;
+    fn next_id(self: Arc<Self>) -> StoreSelectorID;
+    fn needs_authentication(&self) -> bool;
+    fn authentication_metadata(&self) -> Option<StoreAuthenticationMetadata>;
+    fn authenticate(
+        &self,
+        kind: Bytes,
+        message: Option<Bytes>,
+    ) -> Result<(Option<Bytes>, bool), protocol::Error>;
+    fn insert_handle(
+        self: Arc<Self>,
+        id: StoreSelectorID,
+        handle: Arc<dyn CredentialBackendHandle + Send + Sync>,
+    );
+    fn get_handle(
+        self: Arc<Self>,
+        id: StoreSelectorID,
+    ) -> Option<Arc<dyn CredentialBackendHandle + Send + Sync>>;
+    fn search_credential(
+        self: Arc<Self>,
+        id: StoreSelectorID,
+        cred: &CredentialRequest,
+    ) -> Result<Option<(Credential, Bytes)>, CredentialParserError>;
+    fn write_credential(
+        self: Arc<Self>,
+        id: StoreSelectorID,
+        cred: &Credential,
+        overwrite: bool,
+        create: bool,
+    ) -> Result<Bytes, CredentialParserError>;
+    fn delete_credential(
+        self: Arc<Self>,
+        id: StoreSelectorID,
+        cred: &Credential,
+    ) -> Result<(), CredentialParserError>;
+    fn delete_credential_by_id(
+        self: Arc<Self>,
+        id: StoreSelectorID,
+    ) -> Result<(), CredentialParserError>;
+    fn list_entries(
+        self: Arc<Self>,
+        id: StoreSelectorID,
+    ) -> Result<Option<BoxedCredentialBackendHandleIterator>, protocol::Error>;
+    fn exists(self: Arc<Self>, path: Bytes) -> Result<bool, CredentialParserError>;
+    fn read_body(
+        self: Arc<Self>,
+        id: StoreSelectorID,
+    ) -> Result<Option<Box<dyn Any + 'static>>, protocol::Error>;
+    fn create_directory(self: Arc<Self>, path: Bytes) -> Result<(), protocol::Error>;
+}
+
+impl<
+        T: Send + Sync + 'static,
+        U: CommandCredentialBackend<Backend = T> + Send + Sync + 'static,
+    > CredentialBackend for U
+{
+    fn name(&self) -> &[u8] {
+        self.backend_name()
+    }
+
+    fn vaults(&self) -> Result<Cow<'_, [Bytes]>, CredentialParserError> {
+        self.list_vaults()
+    }
+
+    fn vault_by_name(
+        self: Arc<Self>,
+        store_id: StoreID,
+        name: &[u8],
+    ) -> Result<Option<Arc<dyn CredentialVault + Send + Sync>>, CredentialParserError> {
+        if self.clone().list_vaults()?.iter().any(|nm| *nm == name) {
+            let vault = Arc::new(CommandCredentialVault {
+                store_id,
+                id: self.clone().next_id(),
+                name: Bytes::copy_from_slice(name),
+                parent: self.clone(),
+            });
+            self.insert_handle(vault.id, vault.clone().to_handle());
+            Ok(Some(vault))
+        } else {
+            Ok(None)
+        }
+    }
+
+    fn next_handle(
+        self: Arc<Self>,
+        store_id: StoreID,
+        path: Bytes,
+    ) -> Arc<dyn CredentialBackendHandle + Send + Sync> {
+        let id = self.clone().next_id();
+
+        let handle = Arc::new(CommandCredentialBackendHandle {
+            store_id,
+            id,
+            parent: self.clone(),
+            path,
+            credential: Mutex::new(None),
+        });
+        self.insert_handle(id, handle.clone());
+        handle
+    }
+
+    fn handle_from_id(
+        self: Arc<Self>,
+        _store_id: StoreID,
+        id: StoreSelectorID,
+    ) -> Option<Arc<dyn CredentialBackendHandle + Send + Sync>> {
+        self.get_handle(id)
+    }
+
+    fn to_handle(
+        self: Arc<Self>,
+        store_id: StoreID,
+    ) -> Arc<dyn CredentialBackendHandle + Send + Sync> {
+        let path = StorePath::from_components::<&[u8]>(&[b"", self.backend_name(), b""]).unwrap();
+        self.next_handle(store_id, path.into_inner())
+    }
+
+    fn acquire_at_path(
+        self: Arc<Self>,
+        store_id: StoreID,
+        path: Bytes,
+    ) -> Result<Option<Arc<dyn CredentialBackendHandle + Send + Sync>>, CredentialParserError> {
+        if self.clone().exists(path.clone())? {
+            Ok(Some(self.next_handle(store_id, path)))
+        } else {
+            Ok(None)
+        }
+    }
+
+    fn needs_authentication(&self) -> Option<bool> {
+        Some(CommandCredentialBackend::needs_authentication(self))
+    }
+
+    fn authentication_metadata(&self) -> Option<StoreAuthenticationMetadata> {
+        CommandCredentialBackend::authentication_metadata(self)
+    }
+}

--- a/lawn/src/store/credential/memory.rs
+++ b/lawn/src/store/credential/memory.rs
@@ -1,0 +1,883 @@
+use super::helpers::{
+    BoxedCredentialBackendHandleIterator, CommandCredentialBackend, CommandCredentialBackendHandle,
+};
+use super::{CredentialBackendHandle, CredentialElements, CredentialPathComponentType};
+use crate::config::Config;
+use crate::credential::{Credential, CredentialParserError, CredentialRequest};
+use crate::store::{StoreAuthenticationMetadata, StorePath};
+use bytes::Bytes;
+use format_bytes::format_bytes;
+use lawn_constants::logger::AsLogStr;
+use lawn_protocol::protocol::{
+    self, CredentialStoreElement, KeyboardInteractiveAuthenticationPrompt,
+    KeyboardInteractiveAuthenticationRequest, KeyboardInteractiveAuthenticationResponse,
+    ResponseCode, StoreSelectorID,
+};
+use serde::{Deserialize, Serialize};
+use std::any::Any;
+use std::borrow::Cow;
+use std::collections::btree_map::Entry;
+use std::collections::BTreeMap;
+use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
+use std::sync::{Arc, Mutex, RwLock};
+use subtle::ConstantTimeEq;
+
+trait VaultContainer {
+    fn entry(&self, name: &[u8]) -> Option<&VaultEntry>;
+    fn entry_mut(&mut self, name: &[u8]) -> Option<&mut VaultEntry>;
+    fn entries(&self) -> &BTreeMap<Bytes, VaultEntry>;
+    fn entries_mut(&mut self) -> &mut BTreeMap<Bytes, VaultEntry>;
+}
+
+#[derive(Debug, Default, Serialize, Deserialize)]
+pub(super) struct VaultDirectory {
+    entries: BTreeMap<Bytes, VaultEntry>,
+}
+
+impl VaultDirectory {
+    fn new() -> Self {
+        Default::default()
+    }
+}
+
+impl VaultContainer for VaultDirectory {
+    fn entry(&self, name: &[u8]) -> Option<&VaultEntry> {
+        self.entries.get(name)
+    }
+
+    fn entry_mut(&mut self, name: &[u8]) -> Option<&mut VaultEntry> {
+        self.entries.get_mut(name)
+    }
+
+    fn entries(&self) -> &BTreeMap<Bytes, VaultEntry> {
+        &self.entries
+    }
+
+    fn entries_mut(&mut self) -> &mut BTreeMap<Bytes, VaultEntry> {
+        &mut self.entries
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(untagged)]
+pub(super) enum VaultEntry {
+    Credential(Credential),
+    Directory(VaultDirectory),
+}
+
+#[derive(Default, Serialize, Deserialize)]
+pub(super) struct Vault {
+    entries: BTreeMap<Bytes, VaultEntry>,
+}
+
+impl Vault {
+    fn new() -> Self {
+        Default::default()
+    }
+}
+
+impl VaultContainer for Vault {
+    fn entry(&self, name: &[u8]) -> Option<&VaultEntry> {
+        self.entries.get(name)
+    }
+
+    fn entry_mut(&mut self, name: &[u8]) -> Option<&mut VaultEntry> {
+        self.entries.get_mut(name)
+    }
+
+    fn entries(&self) -> &BTreeMap<Bytes, VaultEntry> {
+        &self.entries
+    }
+
+    fn entries_mut(&mut self) -> &mut BTreeMap<Bytes, VaultEntry> {
+        &mut self.entries
+    }
+}
+
+#[derive(Debug, Copy, Clone)]
+enum AuthenticationState {
+    Start,
+    SentKeyboardInteractivePrompt,
+    Authenticated,
+}
+
+impl Default for AuthenticationState {
+    fn default() -> Self {
+        Self::Start
+    }
+}
+
+pub(super) struct LockableData {
+    locked: AtomicBool,
+    auth_state: Mutex<AuthenticationState>,
+    vaults: RwLock<BTreeMap<Bytes, Vault>>,
+}
+
+impl LockableData {
+    fn new(locked: bool) -> Self {
+        Self {
+            locked: AtomicBool::new(locked),
+            auth_state: Mutex::new(AuthenticationState::Start),
+            vaults: RwLock::new(BTreeMap::new()),
+        }
+    }
+
+    fn vaults(&self) -> Option<&RwLock<BTreeMap<Bytes, Vault>>> {
+        if self.locked.load(Ordering::SeqCst) {
+            None
+        } else {
+            Some(&self.vaults)
+        }
+    }
+
+    fn state_as_string(&self) -> &str {
+        if self.vaults().is_some() {
+            "unlocked"
+        } else {
+            "locked"
+        }
+    }
+}
+
+pub struct MemoryCredentialBackend {
+    config: Arc<Config>,
+    name: Bytes,
+    token: Option<String>,
+    next_id: Arc<AtomicU32>,
+    elems: CredentialElements,
+    vaults: LockableData,
+}
+
+impl MemoryCredentialBackend {
+    pub fn new(
+        config: Arc<Config>,
+        elems: CredentialElements,
+        ids: Arc<AtomicU32>,
+        name: Bytes,
+        token: Option<&str>,
+    ) -> Self {
+        Self {
+            config,
+            name,
+            next_id: ids,
+            elems,
+            token: token.map(|t| t.to_owned()),
+            vaults: LockableData::new(token.is_some()),
+        }
+    }
+
+    fn components(&self, id: StoreSelectorID) -> Result<Vec<Bytes>, CredentialParserError> {
+        let handle = self
+            .elems
+            .read()
+            .unwrap()
+            .get(&id)
+            .ok_or(CredentialParserError::NoSuchHandle)?
+            .clone();
+        let elem = handle.clone().to_store_element();
+        Ok(StorePath::new(elem.path()).unwrap().components())
+    }
+
+    fn container_from_components<'a>(
+        &self,
+        lock: &'a BTreeMap<Bytes, Vault>,
+        components: &[Bytes],
+    ) -> Result<Option<&'a dyn VaultContainer>, CredentialParserError> {
+        let logger = self.config.logger();
+        trace!(
+            logger,
+            "server: memory backend: container from components: {:?}",
+            components
+        );
+        if components.len() <= 2 {
+            return Ok(None);
+        }
+        let components = if components.last().map(|x| x.as_ref()) == Some(b"") {
+            &components[0..components.len() - 1]
+        } else {
+            components
+        };
+        let mut entry: &dyn VaultContainer = match lock.get(&components[2]) {
+            Some(entry) => entry,
+            None => return Ok(None),
+        };
+        if components.len() <= 3 {
+            return Ok(Some(entry));
+        }
+        for component in &components[3..] {
+            entry = match entry.entry(component) {
+                Some(VaultEntry::Directory(entry)) => entry,
+                Some(VaultEntry::Credential(_)) | None => return Ok(None),
+            }
+        }
+        Ok(Some(entry))
+    }
+
+    fn container_mut_from_components<'a>(
+        &self,
+        lock: &'a mut BTreeMap<Bytes, Vault>,
+        components: &[Bytes],
+    ) -> Result<Option<&'a mut dyn VaultContainer>, CredentialParserError> {
+        if components.len() <= 2 {
+            return Ok(None);
+        }
+        let mut entry: &mut dyn VaultContainer = match lock.get_mut(&components[2]) {
+            Some(entry) => entry,
+            None => return Ok(None),
+        };
+        if components.len() <= 3 {
+            return Ok(Some(entry));
+        }
+        for component in &components[3..] {
+            entry = match entry.entry_mut(component) {
+                Some(VaultEntry::Directory(entry)) => entry,
+                Some(VaultEntry::Credential(_)) | None => return Ok(None),
+            }
+        }
+        Ok(Some(entry))
+    }
+
+    fn container_for_id<'a>(
+        &self,
+        lock: &'a BTreeMap<Bytes, Vault>,
+        id: StoreSelectorID,
+    ) -> Result<Option<&'a dyn VaultContainer>, CredentialParserError> {
+        let components = self.components(id)?;
+        self.container_from_components(lock, &components)
+    }
+
+    fn parent_container_for_id<'a>(
+        &self,
+        lock: &'a BTreeMap<Bytes, Vault>,
+        id: StoreSelectorID,
+    ) -> Result<Option<(&'a dyn VaultContainer, Bytes)>, CredentialParserError> {
+        let components = self.components(id)?;
+        if components.len() <= 2 {
+            return Ok(None);
+        }
+        let components = if components.last().map(|x| x.as_ref()) == Some(b"") {
+            &components[0..components.len() - 1]
+        } else {
+            &components
+        };
+        match self.container_from_components(lock, &components[..components.len() - 1]) {
+            Ok(Some(c)) => Ok(Some((c, components[components.len() - 1].clone()))),
+            Ok(None) => Ok(None),
+            Err(e) => Err(e),
+        }
+    }
+
+    fn parent_container_mut_for_id<'a>(
+        &self,
+        lock: &'a mut BTreeMap<Bytes, Vault>,
+        id: StoreSelectorID,
+    ) -> Result<Option<(&'a mut dyn VaultContainer, Bytes)>, CredentialParserError> {
+        let components = self.components(id)?;
+        if components.len() <= 2 {
+            return Ok(None);
+        }
+        let components = if components.last().map(|x| x.as_ref()) == Some(b"") {
+            &components[0..components.len() - 1]
+        } else {
+            &components
+        };
+        match self.container_mut_from_components(lock, &components[..components.len() - 1]) {
+            Ok(Some(c)) => Ok(Some((c, components[components.len() - 1].clone()))),
+            Ok(None) => Ok(None),
+            Err(e) => Err(e),
+        }
+    }
+
+    /// Returns the nearest containing directory for `id`, whether `id` itself or its parent.
+    fn containing_directory<'a>(
+        &self,
+        lock: &'a mut BTreeMap<Bytes, Vault>,
+        id: StoreSelectorID,
+    ) -> Result<Option<(&'a mut dyn VaultContainer, Bytes, bool)>, CredentialParserError> {
+        let components = self.components(id)?;
+        if components.len() <= 2 {
+            return Ok(None);
+        }
+        let (last, is_dir) = if components.last().map(|x| x.as_ref()) == Some(b"") {
+            (components[components.len() - 2].clone(), true)
+        } else {
+            (components[components.len() - 1].clone(), false)
+        };
+        match self.container_mut_from_components(lock, &components[..components.len() - 1]) {
+            Ok(Some(c)) => Ok(Some((c, last, is_dir))),
+            Ok(None) => Ok(None),
+            Err(e) => Err(e),
+        }
+    }
+
+    fn search_recursive(
+        req: &CredentialRequest,
+        container: &dyn VaultContainer,
+        path: Bytes,
+    ) -> Result<Option<(Credential, Bytes)>, CredentialParserError> {
+        for (name, entry) in container.entries() {
+            match entry {
+                VaultEntry::Credential(c) if req.matches(c) => {
+                    let path = format_bytes!(b"{}{}", path.as_ref(), name.as_ref());
+                    return Ok(Some((c.clone(), path.into())));
+                }
+                VaultEntry::Credential(_) => continue,
+                VaultEntry::Directory(d) => {
+                    let path = format_bytes!(b"{}{}/", path.as_ref(), name.as_ref());
+                    match Self::search_recursive(req, d, path.into()) {
+                        Ok(Some(r)) => return Ok(Some(r)),
+                        _ => continue,
+                    }
+                }
+            }
+        }
+        Ok(None)
+    }
+}
+
+impl CommandCredentialBackend for MemoryCredentialBackend {
+    type Backend = Arc<Self>;
+
+    fn config(self: Arc<Self>) -> Arc<Config> {
+        self.config.clone()
+    }
+
+    fn backend_name(&self) -> &[u8] {
+        self.name.as_ref()
+    }
+
+    fn backend_type(&self) -> &str {
+        "memory"
+    }
+
+    fn needs_authentication(&self) -> bool {
+        self.vaults.vaults().is_none()
+    }
+
+    fn authentication_metadata(&self) -> Option<StoreAuthenticationMetadata> {
+        if self.needs_authentication() {
+            Some(StoreAuthenticationMetadata {
+                methods: vec![
+                    Bytes::from(b"PLAIN" as &[u8]),
+                    Bytes::from(b"keyboard-interactive" as &[u8]),
+                ],
+            })
+        } else {
+            None
+        }
+    }
+
+    fn authenticate(
+        &self,
+        kind: Bytes,
+        message: Option<Bytes>,
+    ) -> Result<(Option<Bytes>, bool), protocol::Error> {
+        let logger = self.config.logger();
+        let token = self
+            .token
+            .as_ref()
+            .ok_or(protocol::Error::from(ResponseCode::NotSupported))?;
+        let mut state = self.vaults.auth_state.lock().unwrap();
+        trace!(
+            logger,
+            "server: memory credential: kind {}; state {:?}; message {:?}",
+            kind.as_ref().as_log_str(),
+            state,
+            message,
+        );
+        let resp = match (kind.as_ref(), *state, message) {
+            (_, AuthenticationState::Authenticated, _) => Err(ResponseCode::Conflict.into()),
+            (b"keyboard-interactive", AuthenticationState::Start, None) => {
+                let req = KeyboardInteractiveAuthenticationRequest {
+                    name: "Password Authentication".into(),
+                    instruction: "".into(),
+                    prompts: vec![KeyboardInteractiveAuthenticationPrompt {
+                        prompt: "Password".into(),
+                        echo: false,
+                    }],
+                };
+                *state = AuthenticationState::SentKeyboardInteractivePrompt;
+                trace!(
+                    logger,
+                    "server: memory credential: keyboard-interactive auth start"
+                );
+                Ok((
+                    Some(
+                        serde_cbor::to_vec(&req)
+                            .map_err(|_| protocol::Error::from(ResponseCode::AuthenticationFailed))?
+                            .into(),
+                    ),
+                    true,
+                ))
+            }
+            (b"keyboard-interactive", AuthenticationState::Start, Some(_)) => {
+                Err(ResponseCode::Invalid.into())
+            }
+            (b"keyboard-interactive", AuthenticationState::SentKeyboardInteractivePrompt, None) => {
+                Err(ResponseCode::Invalid.into())
+            }
+            (
+                b"keyboard-interactive",
+                AuthenticationState::SentKeyboardInteractivePrompt,
+                Some(r),
+            ) => {
+                let req: KeyboardInteractiveAuthenticationResponse = serde_cbor::from_slice(&r)
+                    .map_err(|_| protocol::Error::from(ResponseCode::AuthenticationFailed))?;
+                if req.responses.len() == 1
+                    && req.responses[0].as_bytes().ct_eq(token.as_bytes()).into()
+                {
+                    trace!(
+                        logger,
+                        "server: memory credential: keyboard-interactive auth ok"
+                    );
+                    *state = AuthenticationState::Authenticated;
+                    self.vaults.locked.store(false, Ordering::SeqCst);
+                    trace!(
+                        logger,
+                        "server: memory credential: vaults: {}",
+                        self.vaults.state_as_string()
+                    );
+                    Ok((None, false))
+                } else {
+                    trace!(
+                        logger,
+                        "server: memory credential: keyboard-interactive auth failed"
+                    );
+                    Err(ResponseCode::AuthenticationFailed.into())
+                }
+            }
+            (b"PLAIN", AuthenticationState::Start, None) => Err(ResponseCode::Invalid.into()),
+            (b"PLAIN", AuthenticationState::Start, Some(msg)) => {
+                let msg = std::str::from_utf8(&msg)
+                    .map_err(|_| protocol::Error::from(ResponseCode::AuthenticationFailed))?;
+                let values = msg.split(|x| u32::from(x) == 0).collect::<Vec<_>>();
+                if values.len() != 3 {
+                    return Err(ResponseCode::AuthenticationFailed.into());
+                }
+                if values[0].is_empty()
+                    && values[1].is_empty()
+                    && values[2].as_bytes().ct_eq(token.as_bytes()).into()
+                {
+                    trace!(logger, "server: memory credential: PLAIN auth ok");
+                    *state = AuthenticationState::Authenticated;
+                    self.vaults.locked.store(false, Ordering::SeqCst);
+                    trace!(
+                        logger,
+                        "server: memory credential: vaults: {}",
+                        self.vaults.state_as_string()
+                    );
+                    Ok((None, false))
+                } else {
+                    trace!(logger, "server: memory credential: PLAIN auth failed");
+                    Err(ResponseCode::AuthenticationFailed.into())
+                }
+            }
+            (_, _, _) => {
+                trace!(logger, "server: memory credential: invalid message",);
+                Err(ResponseCode::Invalid.into())
+            }
+        };
+        if resp.is_err() {
+            *state = AuthenticationState::Start;
+        }
+        resp
+    }
+
+    fn list_vaults(&self) -> Result<Cow<'_, [Bytes]>, CredentialParserError> {
+        let logger = self.config.logger();
+        trace!(
+            logger,
+            "server: memory credential: list vaults: vaults: {}",
+            self.vaults.state_as_string()
+        );
+        let vaults = self
+            .vaults
+            .vaults()
+            .ok_or(CredentialParserError::Unauthenticated)?
+            .read()
+            .unwrap();
+        Ok(Cow::Owned(vaults.keys().cloned().collect()))
+    }
+
+    fn next_id(self: Arc<Self>) -> StoreSelectorID {
+        StoreSelectorID(self.next_id.fetch_add(1, Ordering::AcqRel))
+    }
+
+    fn insert_handle(
+        self: Arc<Self>,
+        id: StoreSelectorID,
+        handle: Arc<dyn CredentialBackendHandle + Send + Sync>,
+    ) {
+        self.elems.write().unwrap().insert(id, handle.clone());
+    }
+
+    fn get_handle(
+        self: Arc<Self>,
+        id: StoreSelectorID,
+    ) -> Option<Arc<dyn CredentialBackendHandle + Send + Sync>> {
+        self.elems.read().unwrap().get(&id).cloned()
+    }
+
+    fn search_credential(
+        self: Arc<Self>,
+        id: StoreSelectorID,
+        req: &CredentialRequest,
+    ) -> Result<Option<(Credential, Bytes)>, CredentialParserError> {
+        let vaults = self
+            .vaults
+            .vaults()
+            .ok_or(CredentialParserError::Unauthenticated)?
+            .read()
+            .unwrap();
+        let handle = self
+            .elems
+            .read()
+            .unwrap()
+            .get(&id)
+            .ok_or(CredentialParserError::NoSuchHandle)?
+            .clone();
+        let elem = handle.clone().to_store_element();
+        let container = match self.container_for_id(&vaults, id) {
+            Ok(Some(c)) => c,
+            Ok(None) => return Ok(None),
+            Err(e) => return Err(e),
+        };
+        Self::search_recursive(req, container, elem.path())
+    }
+
+    fn write_credential(
+        self: Arc<Self>,
+        id: StoreSelectorID,
+        cred: &Credential,
+        overwrite: bool,
+        create: bool,
+    ) -> Result<Bytes, CredentialParserError> {
+        let logger = self.clone().config().logger();
+        let mut vaults = self
+            .vaults
+            .vaults()
+            .ok_or(CredentialParserError::Unauthenticated)?
+            .write()
+            .unwrap();
+        let handle = self
+            .elems
+            .read()
+            .unwrap()
+            .get(&id)
+            .ok_or(CredentialParserError::NoSuchHandle)?
+            .clone();
+        let (container, component, is_dir) = match self.containing_directory(&mut vaults, id) {
+            Ok(Some(c)) => c,
+            Ok(None) => return Err(CredentialParserError::NoSuchHandle),
+            Err(e) => return Err(e),
+        };
+        let last_item = if is_dir { cred.id.clone() } else { component };
+        let entries = container.entries_mut();
+        let mut components = StorePath::new(handle.to_store_element().path())
+            .unwrap()
+            .components();
+        let last_idx = components.len() - 1;
+        if components[last_idx].as_ref() == b"" {
+            components[last_idx] = last_item.clone();
+        }
+        let path = StorePath::from_components(&components)
+            .unwrap()
+            .into_inner();
+        trace!(
+            logger,
+            "server: memory backend: write credential: overwrite {}; create {}; entries {}, path {}",
+            overwrite,
+            create,
+            entries.contains_key(&last_item),
+            path.as_ref().as_log_str(),
+        );
+        match (overwrite, create, entries.entry(last_item)) {
+            (true, _, Entry::Occupied(mut e)) => match (e.get_mut(), create) {
+                (VaultEntry::Credential(ref mut c), _) => {
+                    *c = cred.clone();
+                    Ok(path)
+                }
+                (VaultEntry::Directory(d), true) => {
+                    d.entries
+                        .insert(cred.id(), VaultEntry::Credential(cred.clone()));
+                    Ok(path)
+                }
+                (VaultEntry::Directory(_), false) => Err(CredentialParserError::NoSuchHandle),
+            },
+            (_, true, Entry::Vacant(e)) => {
+                e.insert(VaultEntry::Credential(cred.clone()));
+                Ok(path)
+            }
+            (_, _, _) => Err(CredentialParserError::NoSuchHandle),
+        }
+    }
+
+    fn delete_credential(
+        self: Arc<Self>,
+        id: StoreSelectorID,
+        _cred: &Credential,
+    ) -> Result<(), CredentialParserError> {
+        self.delete_credential_by_id(id)
+    }
+
+    fn delete_credential_by_id(
+        self: Arc<Self>,
+        id: StoreSelectorID,
+    ) -> Result<(), CredentialParserError> {
+        let mut vaults = self
+            .vaults
+            .vaults()
+            .ok_or(CredentialParserError::Unauthenticated)?
+            .write()
+            .unwrap();
+        let (container, component) = match self.parent_container_mut_for_id(&mut vaults, id) {
+            Ok(Some(c)) => c,
+            Ok(None) => return Err(CredentialParserError::NoSuchHandle),
+            Err(e) => return Err(e),
+        };
+        let entries = container.entries_mut();
+        match entries.remove(&component) {
+            Some(_) => Ok(()),
+            None => Err(CredentialParserError::NoSuchHandle),
+        }
+    }
+
+    fn listable(&self) -> bool {
+        false
+    }
+
+    fn list_entries(
+        self: Arc<Self>,
+        id: StoreSelectorID,
+    ) -> Result<Option<BoxedCredentialBackendHandleIterator>, protocol::Error> {
+        let logger = self.config.logger();
+        trace!(
+            logger,
+            "server: memory credential: list entries: vaults: {}",
+            self.vaults.state_as_string(),
+        );
+        let handle = self
+            .elems
+            .read()
+            .unwrap()
+            .get(&id)
+            .ok_or(ResponseCode::NotFound)?
+            .clone();
+        let elem = handle.clone().to_store_element();
+        trace!(
+            logger,
+            "server: memory credential: list entries: id {}: {}",
+            id.0,
+            elem.path().as_ref().as_log_str(),
+        );
+        let vaults = self
+            .vaults
+            .vaults()
+            .ok_or(ResponseCode::NeedsAuthentication)?
+            .write()
+            .unwrap();
+        let path = elem.path();
+        let store_id = elem.store_id();
+        if let Some(CredentialPathComponentType::Backend) =
+            CredentialPathComponentType::from_path(elem.path())
+        {
+            let this = self.clone();
+            let items: Vec<_> = vaults
+                .keys()
+                .map(|name| {
+                    let mut components = StorePath::new(path.clone()).unwrap().components();
+                    components.pop();
+                    let handle: Arc<dyn CredentialBackendHandle + Send + Sync> = {
+                        components.extend(
+                            (&[name.clone(), Bytes::from(b"" as &[u8])] as &[Bytes])
+                                .iter()
+                                .cloned(),
+                        );
+                        let path = StorePath::from_components(&components)
+                            .unwrap()
+                            .into_inner();
+                        Arc::new(CommandCredentialBackendHandle::new(
+                            store_id,
+                            id,
+                            path,
+                            this.clone(),
+                        ))
+                    };
+                    this.clone().insert_handle(id, handle.clone());
+                    handle
+                })
+                .collect();
+            return Ok(Some(Box::new(items.into_iter())));
+        }
+        let container = match self.container_for_id(&vaults, id) {
+            Ok(Some(c)) => c,
+            Ok(None) => return Ok(None),
+            Err(CredentialParserError::Unlistable) => return Err(ResponseCode::Unlistable.into()),
+            Err(e) => {
+                trace!(
+                    logger,
+                    "server: memory credential: list entries: error: {}",
+                    e
+                );
+                return Err(ResponseCode::InternalError.into());
+            }
+        };
+        if elem.kind() != b"directory" {
+            return Err(ResponseCode::NotSupported.into());
+        }
+        let this = self.clone();
+        let items: Vec<_> = container
+            .entries()
+            .iter()
+            .map(move |(name, entry)| {
+                let id = this.clone().next_id();
+                let mut components = StorePath::new(path.clone()).unwrap().components();
+                components.pop();
+                let handle: Arc<dyn CredentialBackendHandle + Send + Sync> =
+                    if let VaultEntry::Credential(c) = entry {
+                        components.extend((&[name.clone()] as &[Bytes]).iter().cloned());
+                        let path = StorePath::from_components(&components)
+                            .unwrap()
+                            .into_inner();
+                        Arc::new(CommandCredentialBackendHandle::new_with_credential(
+                            store_id,
+                            id,
+                            path,
+                            this.clone(),
+                            c.clone(),
+                        ))
+                    } else {
+                        components.extend(
+                            (&[name.clone(), Bytes::from(b"" as &[u8])] as &[Bytes])
+                                .iter()
+                                .cloned(),
+                        );
+                        let path = StorePath::from_components(&components)
+                            .unwrap()
+                            .into_inner();
+                        Arc::new(CommandCredentialBackendHandle::new(
+                            store_id,
+                            id,
+                            path,
+                            this.clone(),
+                        ))
+                    };
+                this.clone().insert_handle(id, handle.clone());
+                handle
+            })
+            .collect();
+        Ok(Some(Box::new(items.into_iter())))
+    }
+
+    fn create_directory(self: Arc<Self>, path: Bytes) -> Result<(), protocol::Error> {
+        let logger = self.clone().config().logger();
+        let components = StorePath::new(path.clone())
+            .ok_or(ResponseCode::Invalid)?
+            .components();
+        let kind = CredentialPathComponentType::from_path_components(&components);
+        trace!(
+            logger,
+            "server: creating directory at {} of kind {:?}",
+            path.as_ref().as_log_str(),
+            kind
+        );
+        match kind {
+            Some(CredentialPathComponentType::Top)
+            | Some(CredentialPathComponentType::Backend)
+            | Some(CredentialPathComponentType::Entry) => Err(ResponseCode::NotSupported.into()),
+            Some(CredentialPathComponentType::Vault) => {
+                let vaults = self
+                    .vaults
+                    .vaults()
+                    .ok_or(protocol::Error::from(ResponseCode::NeedsAuthentication))?;
+                let mut vaults = vaults.write().unwrap();
+                match vaults.entry(components[components.len() - 2].clone()) {
+                    Entry::Occupied(_) => Err(ResponseCode::Conflict.into()),
+                    Entry::Vacant(e) => {
+                        e.insert(Vault::new());
+                        Ok(())
+                    }
+                }
+            }
+            Some(CredentialPathComponentType::VaultDirectory) => {
+                let vaults = self
+                    .vaults
+                    .vaults()
+                    .ok_or(protocol::Error::from(ResponseCode::NeedsAuthentication))?;
+                let mut vaults = vaults.write().unwrap();
+                match self
+                    .container_mut_from_components(&mut vaults, &components[..components.len() - 2])
+                {
+                    Ok(Some(c)) => {
+                        c.entries_mut().insert(
+                            components[components.len() - 2].clone(),
+                            VaultEntry::Directory(VaultDirectory::new()),
+                        );
+                        Ok(())
+                    }
+                    Ok(None) => Err(ResponseCode::NotFound.into()),
+                    Err(_) => Err(ResponseCode::InternalError.into()),
+                }
+            }
+            None => Err(ResponseCode::Invalid.into()),
+        }
+    }
+
+    fn exists(self: Arc<Self>, path: Bytes) -> Result<bool, CredentialParserError> {
+        let vaults = self
+            .vaults
+            .vaults()
+            .ok_or(CredentialParserError::Unauthenticated)?;
+        let vaults = vaults.read().unwrap();
+        let components = match StorePath::new(path) {
+            Some(c) => c.components(),
+            None => return Ok(false),
+        };
+        if components.len() <= 2 {
+            return Ok(false);
+        }
+        let components = if components.last().map(|x| x.as_ref()) == Some(b"") {
+            &components[0..components.len() - 1]
+        } else {
+            &components
+        };
+        let mut entry: &dyn VaultContainer = match vaults.get(&components[2]) {
+            Some(entry) => entry,
+            None => return Ok(false),
+        };
+        if components.len() <= 3 {
+            return Ok(true);
+        }
+        let iterable = &components[3..];
+        for (count, component) in iterable.iter().enumerate() {
+            let is_last = iterable.is_empty() || count == iterable.len() - 1;
+            entry = match entry.entry(component) {
+                Some(VaultEntry::Directory(entry)) => entry,
+                Some(VaultEntry::Credential(_)) => return Ok(is_last),
+                None => return Ok(false),
+            }
+        }
+        Ok(true)
+    }
+
+    fn read_body(
+        self: Arc<Self>,
+        id: StoreSelectorID,
+    ) -> Result<Option<Box<dyn Any + 'static>>, protocol::Error> {
+        let vaults = self
+            .vaults
+            .vaults()
+            .ok_or(ResponseCode::NeedsAuthentication)?;
+        let vaults = vaults.read().unwrap();
+        let (cont, last) = self
+            .parent_container_for_id(&vaults, id)
+            .map_err(|_| ResponseCode::NotFound)?
+            .ok_or(ResponseCode::NotFound)?;
+        if let Some(VaultEntry::Credential(ref c)) = cont.entries().get(&last) {
+            let cse: CredentialStoreElement = c.into();
+            Ok(Some(Box::new(cse)))
+        } else {
+            Ok(None)
+        }
+    }
+}

--- a/lawn/src/tests.rs
+++ b/lawn/src/tests.rs
@@ -45,14 +45,16 @@ impl FakeEnvironment {
 
     fn env(&self, s: &str) -> Option<OsString> {
         let cwd = std::env::current_dir().unwrap();
+        let path = std::env::var_os("PATH").unwrap();
         let subpath: Cow<'static, [u8]> = match s {
             "HOME" => Some(Cow::Borrowed(b"home" as &[u8])),
             "XDG_RUNTIME_DIR" => Some(Cow::Borrowed(b"runtime" as &[u8])),
             "LAWN_TEST_DATA_DIR" => Some(Cow::Borrowed(b"data" as &[u8])),
             "PATH" => {
                 return Some(OsString::from_vec(format_bytes!(
-                    b"{}/../spec/fixtures/bin:/bin:/usr/bin:/sbin:/usr/sbin",
-                    cwd.as_os_str().as_bytes()
+                    b"{}/../spec/fixtures/bin:{}",
+                    cwd.as_os_str().as_bytes(),
+                    path.as_bytes(),
                 )))
             }
             _ => None,

--- a/spec/fixtures/bin/git-backend
+++ b/spec/fixtures/bin/git-backend
@@ -1,0 +1,83 @@
+#!/usr/bin/env ruby
+
+require 'json'
+require 'uri'
+
+def read_data(fp)
+  entries = {}
+  fp.each_line do |ln|
+    key, value = ln.chomp.split('=', 2)
+    entries[key.to_sym] = value
+  end
+  $stderr.puts("git-backend: trace: read: #{entries.inspect}")
+  args = {
+    host: entries[:host],
+  }
+  args[:path] = entries[:path] unless entries[:path].nil?
+  if entries[:protocol] == "http"
+    [URI::HTTP.build(**args), entries[:username], entries[:password], entries]
+  else
+    [URI::HTTPS.build(**args), entries[:username], entries[:password], entries]
+  end
+end
+
+def fill(fpin, fpout, data)
+  url, user, _, entries = read_data(fpin)
+  if entry = data[url.to_s]
+    if user && entry[user]
+      entries[:username] = user
+      entries[:password] = entry[user]
+    elsif !user
+      entries[:username], entries[:password] = entry.first
+    end
+    $stderr.puts("git-backend: trace: fill: #{entries.inspect}")
+    entries.each do |k, v|
+      fpout.puts("#{k}=#{v}")
+    end
+  end
+  data
+end
+
+def approve(fpin, data)
+  url, user, pass, _ = read_data(fpin)
+  data[url.to_s] ||= {}
+  data[url.to_s][user] = pass
+  data
+end
+
+def reject(fpin, data)
+  url, user, _, _ = read_data(fpin)
+  data[url.to_s] ||= {}
+  data[url.to_s].delete(user)
+  data
+end
+
+DATA_FILE = File.join(ENV["LAWN_TEST_DATA_DIR"], "git")
+fp, data = if File.exist? DATA_FILE
+             fp = File.open(DATA_FILE, "r+")
+             contents = fp.read
+             data = contents.length == 0 ? {} : JSON.parse(contents)
+             [fp, data]
+           else
+             fp = File.open(DATA_FILE, "w+")
+             data = {}
+             [fp, data]
+           end
+
+$stderr.puts("git-backend: trace: start data: #{data.inspect}")
+
+case ARGV[0]
+when "fill"
+  data = fill($stdin, $stdout, data)
+when "approve"
+  data = approve($stdin, data)
+when "reject"
+  data = reject($stdin, data)
+else
+  raise "Sorry, I don't know how to do that (#{ARGV[0]})."
+end
+
+fp.rewind
+fp.truncate(0)
+$stderr.puts("git-backend: trace: end data: #{data.inspect}")
+fp.write(JSON.generate(data))


### PR DESCRIPTION
Add a new type of abstraction, a store, and add a variant of this that handles credentials.  Add a backend for Git and one for an in-memory store which persists during the entire life of the server.

Partially implements #20