### PR TITLE
Apply several security updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,17 +2,17 @@ name: ci
 on: [push, pull_request]
 
 jobs:
-  build-bullseye:
-    name: Linux (Debian bullseye amd64)
+  build-bookworm:
+    name: Linux (Debian bookworm amd64)
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: 3.1
-    - run: make ci-bullseye
-  build-bullseye-arm64:
-    name: Linux (Debian bullseye arm64)
+    - run: make ci-bookworm
+  build-bookworm-arm64:
+    name: Linux (Debian bookworm arm64)
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
@@ -24,7 +24,7 @@ jobs:
         sudo systemctl restart docker.service
         docker version -f '{{.Server.Experimental}}'
     - uses: docker/setup-qemu-action@v2
-    - run: make ci-bullseye
+    - run: make ci-bookworm
       env:
         PLATFORM: linux/arm64
   build-oldest:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,17 +4,13 @@ version = 3
 
 [[package]]
 name = "ahash"
-version = "0.3.8"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8fd72866655d1904d6b0997d0b07ba561047d070fbe29de039031c641b61217"
-
-[[package]]
-name = "ansi_term"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
+checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
 dependencies = [
- "winapi",
+ "getrandom",
+ "once_cell",
+ "version_check",
 ]
 
 [[package]]
@@ -26,17 +22,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi 0.1.19",
- "libc",
- "winapi",
 ]
 
 [[package]]
@@ -92,12 +77,6 @@ checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
 
 [[package]]
 name = "cfg-if"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
-
-[[package]]
-name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
@@ -108,48 +87,9 @@ version = "2.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
 dependencies = [
- "ansi_term",
- "atty",
  "bitflags",
- "strsim",
  "textwrap",
  "unicode-width",
- "vec_map",
-]
-
-[[package]]
-name = "cloudabi"
-version = "0.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
-dependencies = [
- "bitflags",
-]
-
-[[package]]
-name = "crossbeam-epoch"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "058ed274caafc1f60c4997b5fc07bf7dc7cca454af7c6e81edffe5f33f70dace"
-dependencies = [
- "autocfg",
- "cfg-if 0.1.10",
- "crossbeam-utils",
- "lazy_static",
- "maybe-uninit",
- "memoffset",
- "scopeguard",
-]
-
-[[package]]
-name = "crossbeam-utils"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8"
-dependencies = [
- "autocfg",
- "cfg-if 0.1.10",
- "lazy_static",
 ]
 
 [[package]]
@@ -191,7 +131,7 @@ checksum = "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a"
 dependencies = [
  "errno-dragonfly",
  "libc",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -215,14 +155,14 @@ dependencies = [
 
 [[package]]
 name = "flurry"
-version = "0.3.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c0a35f7b50e99185a2825541946252f669f3c3ca77801357cd682a1b356bb3e"
+checksum = "3e0afc943ef18eebf6bc3335daeb8d338202093d18444a1784ea7f57fe7680f8"
 dependencies = [
  "ahash",
- "crossbeam-epoch",
  "num_cpus",
  "parking_lot",
+ "seize",
 ]
 
 [[package]]
@@ -262,6 +202,17 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe9006bed769170c11f845cf00c7c1e9092aeb3f268e007c3e760ac68008070f"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
 ]
 
 [[package]]
@@ -323,7 +274,7 @@ version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
 ]
 
 [[package]]
@@ -334,7 +285,7 @@ checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
 dependencies = [
  "hermit-abi 0.3.1",
  "libc",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -447,16 +398,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "lazy_static"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
-
-[[package]]
 name = "libc"
-version = "0.2.146"
+version = "0.2.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f92be4933c13fd498862a9e02a3055f8a8d9c039ce33db97306fd5a6caa7f29b"
+checksum = "89d92a4743f9a61002fae18374ed11e7973f530cb3a3255fb354818118b2203c"
 
 [[package]]
 name = "linked-hash-map"
@@ -472,10 +417,11 @@ checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
 
 [[package]]
 name = "lock_api"
-version = "0.3.4"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4da24a77a3d8a6d4862d95f72e6fdb9c09a643ecdb402d754004a557f2bec75"
+checksum = "3c168f8615b12bc01f9c17e2eb0cc07dcae1940121185446edc3744920e8ef45"
 dependencies = [
+ "autocfg",
  "scopeguard",
 ]
 
@@ -485,14 +431,8 @@ version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
 ]
-
-[[package]]
-name = "maybe-uninit"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
 
 [[package]]
 name = "memchr"
@@ -501,43 +441,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
 
 [[package]]
-name = "memoffset"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "043175f069eda7b85febe4a74abbaeff828d9f8b448515d3151a14a3542811aa"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
 name = "mio"
-version = "0.7.14"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8067b404fe97c70829f082dec8bcf4f71225d7eaea1d8645349cb76fa06205cc"
+checksum = "8f3d0b296e374a4e6f3c7b0a1f5a51d748a0d34c85e7dc48fc3fa9a87657fe09"
 dependencies = [
  "libc",
  "log",
- "miow",
- "ntapi",
- "winapi",
-]
-
-[[package]]
-name = "miow"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9f1c5b025cda876f66ef43a113f91ebc9f4ccef34843000e0adf6ebbab84e21"
-dependencies = [
- "winapi",
-]
-
-[[package]]
-name = "ntapi"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f6bb902e437b6d86e03cce10a7e2af662292c5dfef23b65899ea3ac9354ad44"
-dependencies = [
- "winapi",
+ "wasi",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -572,15 +484,15 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.13.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18a6dbe30758c9f83eb00cbea4ac95966305f5a7772f3f42ebfc7fc7eddbd8e1"
+checksum = "074864da206b4973b84eb91683020dbefd6a8c3f0f38e054d93954e891935e4e"
 
 [[package]]
 name = "parking_lot"
-version = "0.10.2"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3a704eb390aafdc107b0e392f56a82b668e3a71366993b5340f5833fd62505e"
+checksum = "87f5ec2493a61ac0506c0f4199f99070cbe83857b0337006a30f3e6719b8ef58"
 dependencies = [
  "lock_api",
  "parking_lot_core",
@@ -588,16 +500,15 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.7.2"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d58c7c768d4ba344e3e8d72518ac13e259d7c7ade24167003b8488e10b6740a3"
+checksum = "b2f4f894f3865f6c0e02810fc597300f34dc2510f66400da262d8ae10e75767d"
 dependencies = [
- "cfg-if 0.1.10",
- "cloudabi",
+ "cfg-if",
  "libc",
- "redox_syscall 0.1.57",
+ "redox_syscall 0.2.10",
  "smallvec",
- "winapi",
+ "windows-sys 0.29.0",
 ]
 
 [[package]]
@@ -632,12 +543,6 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.1.57"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
-
-[[package]]
-name = "redox_syscall"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8383f39639269cde97d255a32bdb68c047337295414940c68bdd30c2e13203ff"
@@ -646,26 +551,26 @@ dependencies = [
 ]
 
 [[package]]
-name = "remove_dir_all"
-version = "0.5.3"
+name = "redox_syscall"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
+checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
 dependencies = [
- "winapi",
+ "bitflags",
 ]
 
 [[package]]
 name = "rustix"
-version = "0.37.19"
+version = "0.37.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acf8729d8542766f1b2cf77eb034d52f40d375bb8b615d0b147089946e16613d"
+checksum = "84f3f8f960ed3b5a59055428714943298bf3fa2d4a1d53135084e0544829d995"
 dependencies = [
  "bitflags",
  "errno",
  "io-lifetimes",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -679,6 +584,16 @@ name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
+name = "seize"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce93c8d45363e39026e0031c7e34fd3ae18d6415d9ecb68b8090bd30e9d26971"
+dependencies = [
+ "num_cpus",
+ "once_cell",
+]
 
 [[package]]
 name = "serde"
@@ -770,10 +685,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 
 [[package]]
-name = "strsim"
-version = "0.8.0"
+name = "socket2"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
+checksum = "9f7916fc008ca5542385b89a3d3ce689953c143e9304a9bf8beec1de48994c0d"
+dependencies = [
+ "libc",
+ "winapi",
+]
 
 [[package]]
 name = "subtle"
@@ -794,16 +713,15 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.3.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
+checksum = "b9fbec84f381d5795b08656e4912bec604d162bff9291d6189a78f4c8ab87998"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "fastrand",
- "libc",
- "redox_syscall 0.2.10",
- "remove_dir_all",
- "winapi",
+ "redox_syscall 0.3.5",
+ "rustix",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -852,18 +770,18 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.16.1"
+version = "1.18.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c27a64b625de6d309e8c57716ba93021dccf1b3b5c97edd6d3dd2d2135afc0a"
+checksum = "0e050c618355082ae5a89ec63bbf897225d5ffe84c7c4e036874e4d185a5044e"
 dependencies = [
  "bytes",
  "libc",
  "memchr",
  "mio",
  "num_cpus",
- "once_cell",
  "pin-project-lite",
  "signal-hook-registry",
+ "socket2",
  "tokio-macros",
  "winapi",
 ]
@@ -934,16 +852,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "vec_map"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
-
-[[package]]
 name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "winapi"
@@ -969,11 +887,48 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ceb069ac8b2117d36924190469735767f0990833935ab430155e71a44bafe148"
+dependencies = [
+ "windows_aarch64_msvc 0.29.0",
+ "windows_i686_gnu 0.29.0",
+ "windows_i686_msvc 0.29.0",
+ "windows_x86_64_gnu 0.29.0",
+ "windows_x86_64_msvc 0.29.0",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.48.0",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -982,14 +937,20 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b1eb6f0cd7c80c79759c929114ef071b87354ce476d9d94271031c0497adfd5"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.48.0",
+ "windows_aarch64_msvc 0.48.0",
+ "windows_i686_gnu 0.48.0",
+ "windows_i686_msvc 0.48.0",
+ "windows_x86_64_gnu 0.48.0",
+ "windows_x86_64_gnullvm 0.48.0",
+ "windows_x86_64_msvc 0.48.0",
 ]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -999,9 +960,33 @@ checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d027175d00b01e0cbeb97d6ab6ebe03b12330a35786cbaca5252b1c4bf5d9b"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8793f59f7b8e8b01eda1a652b2697d87b93097198ae85f823b969ca5b89bba58"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1011,9 +996,33 @@ checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8602f6c418b67024be2996c512f5f995de3ba417f4c75af68401ab8756796ae4"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3d615f419543e0bd7d2b3323af0d86ff19cbc4f816e6453f36a2c2ce889c354"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -1023,9 +1032,27 @@ checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d95421d9ed3672c280884da53201a5c46b7b2765ca6faf34b0d71cf34a3561"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Test configuration.
-GROUPS := bullseye stable nightly oldest
+GROUPS := bookworm stable nightly oldest
 DOCKER_FILES := $(patsubst %,test/Dockerfile.%,$(GROUPS))
 DOCKER_STAMPS := $(patsubst %,test/Dockerfile.%.stamp,$(GROUPS))
 CI_TARGETS := $(patsubst %,ci-%,$(GROUPS))

--- a/README.adoc
+++ b/README.adoc
@@ -24,7 +24,7 @@ Note that while Lawn has some access control built in, it is only designed for t
 If you expose the socket on an untrusted machine, you may very well end up with a security problem.
 Please don't do that.
 
-Lawn should run on any Unix system with Rust 1.48.0 or newer.
+Lawn should run on any Unix system with Rust 1.63.0 or newer.
 If it doesn't work on your Unix system, let us know, and we'll try to get it fixed.
 
 Note that this tool is currently highly Unix specific and makes copious use of Unix sockets, Unix error codes, and the Unix-based Rust extensions.

--- a/lawn-9p/Cargo.toml
+++ b/lawn-9p/Cargo.toml
@@ -19,7 +19,7 @@ rust-version = "1.63.0"
 lawn-constants = { path = "../lawn-constants", version = "0.3.0" }
 lawn-fs = { path = "../lawn-fs", version = "0.3.0", features = ["unix"] }
 hex = "0.4"
-flurry = "0.3"
+flurry = "0.4"
 libc = "0.2"
 bitflags = "1.3"
 num-traits = "0.2"

--- a/lawn-9p/Cargo.toml
+++ b/lawn-9p/Cargo.toml
@@ -13,7 +13,7 @@ include = [
     "README.md",
     "LICENSE",
 ]
-rust-version = "1.48.0"
+rust-version = "1.63.0"
 
 [dependencies]
 lawn-constants = { path = "../lawn-constants", version = "0.3.0" }

--- a/lawn-constants/Cargo.toml
+++ b/lawn-constants/Cargo.toml
@@ -13,7 +13,7 @@ include = [
     "README.md",
     "LICENSE",
 ]
-rust-version = "1.48.0"
+rust-version = "1.63.0"
 
 [dependencies]
 libc = "0.2"

--- a/lawn-fs/Cargo.toml
+++ b/lawn-fs/Cargo.toml
@@ -13,7 +13,7 @@ include = [
     "README.md",
     "LICENSE",
 ]
-rust-version = "1.48.0"
+rust-version = "1.63.0"
 
 [dependencies]
 lawn-constants = { path = "../lawn-constants", version = "0.3.0", features = ["rustix"] }

--- a/lawn-fs/Cargo.toml
+++ b/lawn-fs/Cargo.toml
@@ -18,7 +18,7 @@ rust-version = "1.63.0"
 [dependencies]
 lawn-constants = { path = "../lawn-constants", version = "0.3.0", features = ["rustix"] }
 hex = "0.4"
-flurry = "0.3"
+flurry = "0.4"
 rustix = { version = "0.37", features = ["fs", "process"], optional = true }
 bitflags = "1.3"
 num-traits = "0.2"

--- a/lawn-fs/src/backend/libc.rs
+++ b/lawn-fs/src/backend/libc.rs
@@ -971,12 +971,11 @@ impl Backend for LibcBackend {
         }
     }
 
-    fn remove(&self, meta: &Metadata, fid: FID) -> Result<()> {
+    fn remove(&self, _meta: &Metadata, fid: FID) -> Result<()> {
         trace!(self.logger, "FS remove: fid {:?}", fid);
         let g = self.fid.guard();
         match self.fid.get(&fid, &g) {
             Some(fk) => {
-                let _ = self.clunk(meta, fid);
                 let idi = match fk.id_info() {
                     Some(p) => p,
                     _ => return Err(Error::EOPNOTSUPP),
@@ -2303,6 +2302,7 @@ mod tests {
             .unwrap();
         verify_file(&mut inst, fid(3), b"dir/file");
         inst.server.remove(&inst.next_meta(), fid(3)).unwrap();
+        inst.server.clunk(&inst.next_meta(), fid(3)).unwrap();
         verify_closed(&mut inst, fid(3));
     }
 

--- a/lawn-protocol/Cargo.toml
+++ b/lawn-protocol/Cargo.toml
@@ -13,7 +13,7 @@ include = [
     "README.md",
     "LICENSE",
 ]
-rust-version = "1.48.0"
+rust-version = "1.63.0"
 
 [dependencies]
 bitflags = "1.0"

--- a/lawn-sftp/Cargo.toml
+++ b/lawn-sftp/Cargo.toml
@@ -13,7 +13,7 @@ include = [
     "README.md",
     "LICENSE",
 ]
-rust-version = "1.48.0"
+rust-version = "1.63.0"
 
 [dependencies]
 lawn-constants = { path = "../lawn-constants", version = "0.3.0" }

--- a/lawn-sftp/Cargo.toml
+++ b/lawn-sftp/Cargo.toml
@@ -19,7 +19,7 @@ rust-version = "1.63.0"
 lawn-constants = { path = "../lawn-constants", version = "0.3.0" }
 lawn-fs = { path = "../lawn-fs", version = "0.3.0" }
 hex = "0.4"
-flurry = "0.3"
+flurry = "0.4"
 bitflags = "1.3"
 num-traits = "0.2"
 num-derive = "0.3"

--- a/lawn/Cargo.toml
+++ b/lawn/Cargo.toml
@@ -23,7 +23,7 @@ path = "src/main.rs"
 async-trait = "= 0.1.66"
 blake2 = "0.10"
 bytes = "1"
-clap = "2.32"
+clap = { version = "2.32", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_cbor = "0.11"
 serde_json = "1.0"

--- a/lawn/Cargo.toml
+++ b/lawn/Cargo.toml
@@ -13,7 +13,7 @@ include = [
     "README.md",
     "LICENSE",
 ]
-rust-version = "1.48.0"
+rust-version = "1.63.0"
 
 [[bin]]
 name = "lawn"

--- a/lawn/src/credential.rs
+++ b/lawn/src/credential.rs
@@ -1318,20 +1318,15 @@ impl Clone for CredentialParserError {
     }
 }
 
-#[derive(Clone, Debug, Hash, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Default, Clone, Debug, Hash, Eq, PartialEq, Ord, PartialOrd)]
 pub enum FieldRequest {
     LiteralBytes(Bytes),
     LiteralString(String),
     Set(BTreeSet<FieldRequest>),
     Sequence(Vec<FieldRequest>),
+    #[default]
     Any,
     None,
-}
-
-impl Default for FieldRequest {
-    fn default() -> Self {
-        FieldRequest::Any
-    }
 }
 
 impl FieldRequest {

--- a/lawn/src/server.rs
+++ b/lawn/src/server.rs
@@ -1091,7 +1091,7 @@ impl Server {
                             id,
                             Arc::new(CredentialStore::new(
                                 id,
-                                state.config().clone(),
+                                state.config(),
                                 state.shared_state.clone(),
                             )),
                         );

--- a/lawn/src/store/credential.rs
+++ b/lawn/src/store/credential.rs
@@ -597,15 +597,14 @@ impl Store for CredentialStore {
                 Some(CredentialPathComponentType::VaultDirectory)
                 | Some(CredentialPathComponentType::Entry) => {
                     let b = backend.ok_or(protocol::Error::from(ResponseCode::NotFound))?;
-                    b.acquire_at_path(self.id, path.clone())
-                        .map_err(|e| match e {
-                            CredentialParserError::Unlistable => ResponseCode::Unlistable.into(),
-                            CredentialParserError::Unauthenticated => {
-                                ResponseCode::NeedsAuthentication.into()
-                            }
-                            CredentialParserError::NoSuchHandle => ResponseCode::NotFound.into(),
-                            _ => ResponseCode::InternalError.into(),
-                        })
+                    b.acquire_at_path(self.id, path).map_err(|e| match e {
+                        CredentialParserError::Unlistable => ResponseCode::Unlistable.into(),
+                        CredentialParserError::Unauthenticated => {
+                            ResponseCode::NeedsAuthentication.into()
+                        }
+                        CredentialParserError::NoSuchHandle => ResponseCode::NotFound.into(),
+                        _ => ResponseCode::InternalError.into(),
+                    })
                 }
                 None => Err(ResponseCode::NotFound.into()),
             };

--- a/lawn/src/store/credential/git.rs
+++ b/lawn/src/store/credential/git.rs
@@ -67,7 +67,7 @@ impl GitCredentialBackend {
             None,
         );
         proto.clone().send_approve_reject_request(req)?;
-        proto.clone().close_writer();
+        proto.close_writer();
         let _ = child.wait();
         let components: &[&[u8]] = &[b"", self.backend_name(), b"-", &req.id];
         let path = StorePath::from_components(components).unwrap().into_inner();

--- a/lawn/src/store/credential/helpers.rs
+++ b/lawn/src/store/credential/helpers.rs
@@ -456,7 +456,7 @@ impl<
             kind,
             path
         );
-        if let Some(path) = path.clone() {
+        if let Some(path) = path {
             if kind != "directory" {
                 trace!(
                     logger,
@@ -664,7 +664,7 @@ impl<
         store_id: StoreID,
         name: &[u8],
     ) -> Result<Option<Arc<dyn CredentialVault + Send + Sync>>, CredentialParserError> {
-        if self.clone().list_vaults()?.iter().any(|nm| *nm == name) {
+        if self.list_vaults()?.iter().any(|nm| *nm == name) {
             let vault = Arc::new(CommandCredentialVault {
                 store_id,
                 id: self.clone().next_id(),

--- a/lawn/src/store/credential/memory.rs
+++ b/lawn/src/store/credential/memory.rs
@@ -158,7 +158,7 @@ impl MemoryCredentialBackend {
         token: Option<&str>,
         shared_state: Arc<SharedServerState>,
     ) -> Self {
-        let st = shared_state.clone();
+        let st = shared_state;
         let key = Self::key_from_name(name.clone());
         let mut creds = st.credentials().write().unwrap();
         let logger = config.logger();

--- a/test/Dockerfile.bookworm.erb
+++ b/test/Dockerfile.bookworm.erb
@@ -1,4 +1,4 @@
-FROM debian:bullseye
+FROM debian:bookworm
 
 <%= erb 'test/include/apt.erb' -%>
 

--- a/test/Dockerfile.oldest.erb
+++ b/test/Dockerfile.oldest.erb
@@ -1,6 +1,6 @@
 FROM rust:latest
 
-ARG VERSION=1.48.0
+ARG VERSION=1.63.0
 
 <%= erb 'test/include/apt.erb' -%>
 


### PR DESCRIPTION
Apply several security updates to fix various dependent crate vulnerabilities.  As a necessary requirement, raise the MSRV to 1.63.