### PR TITLE
Improve SSH proxy performance

### DIFF
--- a/lawn/src/config.rs
+++ b/lawn/src/config.rs
@@ -469,7 +469,7 @@ impl Config {
                 .and_then(|v| v.poll_ms)
                 .unwrap_or(50)
         };
-        Duration::from_micros(val)
+        Duration::from_millis(val)
     }
 
     pub fn proxy_server_read_timeout(&self) -> Duration {
@@ -484,7 +484,7 @@ impl Config {
                 .and_then(|v| v.server_read_ms)
                 .unwrap_or(15)
         };
-        Duration::from_micros(val)
+        Duration::from_millis(val)
     }
 
     fn clipboard_command_from_str(s: &str) -> Option<ClipboardBackend> {

--- a/lawn/src/main.rs
+++ b/lawn/src/main.rs
@@ -115,6 +115,7 @@ fn find_server_socket(
                         let config = config.clone();
                         let _eg = handle.enter();
                         let (sa, sb) = tokio::net::UnixStream::pair().unwrap();
+                        let _ = sock.set_nonblocking(true);
                         tokio::spawn(async {
                             let p = ssh_proxy::Proxy::new(
                                 config,

--- a/lawn/src/server.rs
+++ b/lawn/src/server.rs
@@ -1541,15 +1541,15 @@ impl Server {
                             >,
                             message
                         );
-                        let mut it = match tokio::task::spawn_blocking(move || {
+                        let res = tokio::task::spawn_blocking(move || {
                             let body: Option<&dyn Any> = match &m.body {
                                 Some(b) => Some(b),
                                 None => None,
                             };
                             se.search(m.kind.map(|k| k.into()), body, m.recurse)
                         })
-                        .await
-                        {
+                        .await;
+                        let mut it = match res {
                             Ok(Ok(res)) => res,
                             Ok(Err(e)) => {
                                 trace!(

--- a/lawn/src/ssh_proxy.rs
+++ b/lawn/src/ssh_proxy.rs
@@ -1,17 +1,20 @@
-use async_trait::async_trait;
 use crate::config::Config;
 use crate::encoding::escape;
+use async_trait::async_trait;
 use num_derive::FromPrimitive;
 use num_traits::FromPrimitive;
 use std::convert::TryInto;
 use std::io;
 use std::path::PathBuf;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
-use tokio::io::AsyncWriteExt;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::unix::{OwnedReadHalf, OwnedWriteHalf};
 use tokio::net::{UnixListener, UnixStream};
 use tokio::select;
+use tokio::sync::mpsc;
+use tokio::sync::oneshot;
 use tokio::sync::Mutex;
 
 #[derive(Copy, Clone, FromPrimitive, Eq, PartialEq)]
@@ -109,12 +112,7 @@ impl Writable for Message {
         let lenbuf = self.len.to_be_bytes();
         let idbuf = self.id.to_be_bytes();
         let nextbuf = self.next.to_be_bytes();
-        let data: &[&[u8]] = &[
-            &lenbuf,
-            &idbuf,
-            &nextbuf,
-            &self.data,
-        ];
+        let data: &[&[u8]] = &[&lenbuf, &idbuf, &nextbuf, &self.data];
         write_full(&data, w).await
     }
 }
@@ -126,6 +124,7 @@ pub enum Error {
     InvalidSize,
     NotSupported,
     NotConnected,
+    Unnotifiable,
 }
 
 impl From<io::Error> for Error {
@@ -176,35 +175,71 @@ impl ProxyListener {
     }
 }
 
+#[allow(clippy::upper_case_acronyms)]
+enum ResponseType {
+    Lawn,
+    LawnPing,
+    SSH(oneshot::Receiver<SSHMessage>),
+}
+
+impl PartialEq for ResponseType {
+    fn eq(&self, other: &ResponseType) -> bool {
+        matches!(
+            (self, other),
+            (ResponseType::Lawn, ResponseType::Lawn)
+                | (ResponseType::LawnPing, ResponseType::LawnPing)
+                | (ResponseType::SSH(_), ResponseType::SSH(_))
+        )
+    }
+}
+
 pub struct Proxy {
-    ssh: Arc<Option<Mutex<UnixStream>>>,
+    ssh_read: Arc<Option<Mutex<OwnedReadHalf>>>,
+    ssh_write: Arc<Option<Mutex<OwnedWriteHalf>>>,
     ours_read: Arc<Mutex<OwnedReadHalf>>,
     ours_write: Arc<Mutex<OwnedWriteHalf>>,
-    multiplex: Arc<Mutex<UnixStream>>,
+    multiplex_read: Arc<Mutex<OwnedReadHalf>>,
+    multiplex_write: Arc<Mutex<OwnedWriteHalf>>,
     config: Arc<Config>,
     server_read_timeout: Duration,
+    lawn_entries: AtomicUsize,
+    ssh_entries: AtomicUsize,
 }
 
 impl Proxy {
+    const CAPACITY: usize = 128;
+
     pub fn new(
         config: Arc<Config>,
         ssh: Option<UnixStream>,
         ours: UnixStream,
         multiplex: UnixStream,
-    ) -> Proxy {
+    ) -> Arc<Proxy> {
         let (rd, wr) = ours.into_split();
+        let (mrd, mwr) = multiplex.into_split();
+        let (sshrd, sshwr) = match ssh {
+            Some(stream) => {
+                let (sshrd, sshwr) = stream.into_split();
+                (
+                    Arc::new(Some(Mutex::new(sshrd))),
+                    Arc::new(Some(Mutex::new(sshwr))),
+                )
+            }
+            None => (Arc::new(None), Arc::new(None)),
+        };
         let server_read_timeout = config.proxy_server_read_timeout();
-        Proxy {
+        Arc::new(Proxy {
             config,
-            ssh: match ssh {
-                Some(ssh) => Arc::new(Some(Mutex::new(ssh))),
-                None => Arc::new(None),
-            },
+            ssh_read: sshrd,
+            ssh_write: sshwr,
             ours_read: Arc::new(Mutex::new(rd)),
             ours_write: Arc::new(Mutex::new(wr)),
-            multiplex: Arc::new(Mutex::new(multiplex)),
+            multiplex_read: Arc::new(Mutex::new(mrd)),
+            multiplex_write: Arc::new(Mutex::new(mwr)),
             server_read_timeout,
-        }
+            lawn_entries: AtomicUsize::new(0),
+            ssh_entries: AtomicUsize::new(0),
+        })
     }
 
     pub async fn client_probe(
@@ -212,13 +247,16 @@ impl Proxy {
         multiplex: std::os::unix::net::UnixStream,
     ) -> Result<std::os::unix::net::UnixStream, Error> {
         let logger = config.logger();
-        let sock = Mutex::new(UnixStream::from_std(multiplex).unwrap());
+        let sock = UnixStream::from_std(multiplex).unwrap();
+        let (mrd, mwr) = sock.into_split();
+        let mwr = Mutex::new(mwr);
+        let mrd = Mutex::new(mrd);
         trace!(logger, "SSH client probe: created socket");
         let m = Self::wrap_message(MessageKind::Extension, None);
         trace!(logger, "SSH client probe: sending message");
-        Self::write_ssh_message(&m, &sock).await?;
+        Self::write_ssh_message(&m, &mwr).await?;
         trace!(logger, "SSH client probe: reading message");
-        let m = Self::read_ssh_message(&sock).await?;
+        let m = Self::read_ssh_message(&mrd).await?;
         if m.kind != MessageKind::Success as u8 {
             trace!(
                 logger,
@@ -228,7 +266,9 @@ impl Proxy {
             return Err(Error::NotSupported);
         }
         trace!(logger, "SSH client probe: ok");
-        Ok(sock.into_inner().into_std().unwrap())
+        let mrd = mrd.into_inner();
+        let mwr = mwr.into_inner();
+        Ok(mrd.reunite(mwr).unwrap().into_std().unwrap())
     }
 
     /// Runs a client to completion.
@@ -236,7 +276,6 @@ impl Proxy {
     /// A proxy client is a service that runs on the client side of the connection and wraps
     /// messages into the SSH protocol for use on the other side.
     pub async fn run_client(&self) -> Result<(), Error> {
-        use tokio::io::AsyncReadExt;
         let mut interval = tokio::time::interval(self.config.proxy_poll_timeout());
         let mut ours_read = self.ours_read.lock().await;
         let logger = self.config.logger();
@@ -269,9 +308,9 @@ impl Proxy {
             "proxy client: writing extension message with {} bytes of data",
             buf.len()
         );
-        self.write_ssh_message_of_type(MessageKind::Extension, buf, &self.multiplex)
+        self.write_ssh_message_of_type(MessageKind::Extension, buf, &self.multiplex_write)
             .await?;
-        let m = Self::read_ssh_message(&self.multiplex).await?;
+        let m = Self::read_ssh_message(&self.multiplex_read).await?;
         if m.kind == MessageKind::Success as u8 && !m.data.is_empty() {
             let mut sock = self.ours_write.lock().await;
             let _ = sock.write_all(&m.data).await;
@@ -284,11 +323,36 @@ impl Proxy {
     /// A proxy server is a service that runs on the server side of the connection and wraps
     /// messages into the SSH protocol for use on the other side.  This will be implemented as an
     /// SSH agent.
-    pub async fn run_server(&self) -> Result<(), Error> {
+    pub async fn run_server(self: Arc<Self>) -> Result<(), Error> {
+        let (tx, rx) = mpsc::channel(Self::CAPACITY);
+        let ssh = self.ssh_read.clone();
+        let logger = self.config.logger();
+        tokio::spawn(async move {
+            if let Err(e) = Self::read_ssh_socket(ssh, rx).await {
+                error!(logger, "error reading SSH socket: {:?}", e);
+            }
+        });
+        let logger = self.config.logger();
+        let (mdtx, mdrx) = mpsc::channel(Self::CAPACITY);
+        let this = self.clone();
+        tokio::spawn(async move {
+            if let Err(e) = this.reply_to_proxy(mdrx).await {
+                if let Error::IOError(e) = e {
+                    if e.kind() != io::ErrorKind::BrokenPipe {
+                        error!(logger, "error replying to messages: {:?}", e);
+                    }
+                } else {
+                    error!(logger, "error replying to messages: {:?}", e);
+                }
+            }
+        });
         loop {
-            let res = Self::read_ssh_message(&self.multiplex).await;
+            let res = Self::read_ssh_message(&self.multiplex_read).await;
             match res {
-                Ok(msg) => self.process_server_ssh_message(&msg).await?,
+                Ok(msg) => {
+                    self.process_server_ssh_message(&msg, tx.clone(), mdtx.clone())
+                        .await?
+                }
                 Err(Error::IOError(e)) if e.kind() == io::ErrorKind::ConnectionReset => {
                     return Ok(())
                 }
@@ -297,14 +361,104 @@ impl Proxy {
         }
     }
 
-    async fn process_server_ssh_message(&self, message: &SSHMessage) -> Result<(), Error> {
+    async fn reply_to_proxy(
+        self: Arc<Self>,
+        mdrx: mpsc::Receiver<ResponseType>,
+    ) -> Result<(), Error> {
+        let mut mdrx = mdrx;
         let logger = self.config.logger();
-        let ssh = self.ssh.clone();
+        let mut buf = vec![0u8; 65536];
+        let ours_read = self.ours_read.lock().await;
+        while let Some(item) = mdrx.recv().await {
+            let (item, count) = {
+                if let ResponseType::Lawn = &item {
+                    let entries = self.lawn_entries.fetch_sub(1, Ordering::AcqRel);
+                    (item, entries)
+                } else {
+                    (item, 0)
+                }
+            };
+            match item {
+                ResponseType::Lawn | ResponseType::LawnPing => {
+                    if count == 0 && item == ResponseType::Lawn {
+                        // There's no other Lawn message in the queue.  Let's wait a bit to see if one
+                        // comes in.
+                        let _ =
+                            tokio::time::timeout(self.server_read_timeout, ours_read.readable())
+                                .await;
+                    } else {
+                        // There's other Lawn messages in the queue, so we should simply attempt to read
+                        // now and if there's nothing, send an immediate response.  A future message will
+                        // handle proxying any leftovers.
+                    }
+                    match ours_read.try_read(&mut buf) {
+                        // We have a message from the server to send.
+                        Ok(n) => {
+                            let buf = &buf[0..n];
+                            trace!(
+                                logger,
+                                "proxy: extension: sending response: {:08x} bytes",
+                                buf.len()
+                            );
+                            self.write_ssh_message_of_type(
+                                MessageKind::Success,
+                                buf,
+                                &self.multiplex_write,
+                            )
+                            .await?;
+                        }
+                        // No message from the server to send.
+                        Err(_) => {
+                            trace!(logger, "proxy: extension: sending empty response");
+                            let m = Self::wrap_message(MessageKind::Success, None);
+                            Self::write_ssh_message(&m, &self.multiplex_write).await?;
+                        }
+                    }
+                }
+                ResponseType::SSH(chan) => {
+                    let data = match chan.await {
+                        Ok(data) => data,
+                        Err(e) => {
+                            trace!(logger, "proxy: ssh: error reading SSH channel: {}", e);
+                            return Err(Error::Unnotifiable);
+                        }
+                    };
+                    Self::write_ssh_message(&data, &self.multiplex_write).await?;
+                }
+            };
+        }
+        Ok(())
+    }
+
+    async fn read_ssh_socket(
+        ssh: Arc<Option<Mutex<OwnedReadHalf>>>,
+        rx: mpsc::Receiver<oneshot::Sender<SSHMessage>>,
+    ) -> Result<(), Error> {
+        let mut rx = rx;
         let ssh = match ssh.as_ref() {
             Some(ssh) => ssh,
             None => return Err(Error::NotConnected),
         };
-        let ours_read = self.ours_read.lock().await;
+        let mut ssh = ssh.lock().await;
+        while let Some(chan) = rx.recv().await {
+            let m = Self::read_ssh_message_unlocked(&mut *ssh).await?;
+            let _ = chan.send(m);
+        }
+        Ok(())
+    }
+
+    async fn process_server_ssh_message(
+        &self,
+        message: &SSHMessage,
+        chan: mpsc::Sender<oneshot::Sender<SSHMessage>>,
+        mdchan: mpsc::Sender<ResponseType>,
+    ) -> Result<(), Error> {
+        let logger = self.config.logger();
+        let sshwr = self.ssh_write.clone();
+        let sshwr = match sshwr.as_ref() {
+            Some(ssh) => ssh,
+            None => return Err(Error::NotConnected),
+        };
         trace!(logger, "proxy: parsing SSH message: {:02x}", message.kind);
         match MessageKind::from_u8(message.kind) {
             Some(MessageKind::Extension) => {
@@ -320,76 +474,38 @@ impl Proxy {
                         let mut ours_write = self.ours_write.lock().await;
                         ours_write.write_all(&ours).await?;
                         trace!(logger, "proxy: relayed message");
-                        let mut buf = vec![0u8; 65536];
-                        let _ =
-                            tokio::time::timeout(self.server_read_timeout, ours_read.readable())
-                                .await;
-                        match ours_read.try_read(&mut buf) {
-                            // We have a message from the server to send.
-                            Ok(n) => {
-                                let buf = &buf[0..n];
-                                trace!(
-                                    logger,
-                                    "proxy: extension: sending response: {:08x} bytes",
-                                    buf.len()
-                                );
-                                self.write_ssh_message_of_type(
-                                    MessageKind::Success,
-                                    buf,
-                                    &self.multiplex,
-                                )
-                                .await?;
-                            }
-                            // No message from the server to send.
-                            Err(_) => {
-                                trace!(logger, "proxy: extension: sending empty response");
-                                let m = Self::wrap_message(MessageKind::Success, None);
-                                Self::write_ssh_message(&m, &self.multiplex).await?;
-                            }
-                        }
-                        // TODO: acknowledge
+                        self.lawn_entries.fetch_add(1, Ordering::AcqRel);
+                        let _ = mdchan.send(ResponseType::Lawn).await;
                     }
                     // One of our extension messages without data.  Basically, a ping of sorts to
                     // see if there's any server data.
                     Some(None) => {
                         trace!(logger, "proxy: found extension message without data");
-                        let mut buf = vec![0u8; 65536];
-                        match ours_read.try_read(&mut buf) {
-                            // We have a message from the server to send.
-                            Ok(n) => {
-                                let buf = &buf[0..n];
-                                trace!(
-                                    logger,
-                                    "proxy: extension: sending response: {:08x} bytes",
-                                    buf.len()
-                                );
-                                self.write_ssh_message_of_type(
-                                    MessageKind::Success,
-                                    buf,
-                                    &self.multiplex,
-                                )
-                                .await?;
-                            }
-                            // No message from the server to send.
-                            Err(_) => {
-                                trace!(logger, "proxy: extension: sending empty response");
-                                let m = Self::wrap_message(MessageKind::Success, None);
-                                Self::write_ssh_message(&m, &self.multiplex).await?;
-                            }
-                        }
+                        self.lawn_entries.fetch_add(1, Ordering::AcqRel);
+                        let _ = mdchan.send(ResponseType::LawnPing).await;
                     }
                     // Another SSH message.
                     None => {
                         trace!(logger, "proxy: found extension message of unknown type");
-                        Self::write_ssh_message(message, ssh).await?;
-                        self.proxy_ssh_message(ssh, &self.multiplex).await?;
+                        let (tx, rx) = oneshot::channel();
+                        let _ = chan.send(tx).await;
+                        Self::write_ssh_message_with_closure(message, sshwr, async {
+                            let _ = mdchan.send(ResponseType::SSH(rx)).await;
+                            self.ssh_entries.fetch_add(1, Ordering::AcqRel);
+                        })
+                        .await?;
                     }
                 }
             }
             _ => {
                 trace!(logger, "proxy: found non-extension message");
-                Self::write_ssh_message(message, ssh).await?;
-                self.proxy_ssh_message(ssh, &self.multiplex).await?;
+                let (tx, rx) = oneshot::channel();
+                let _ = chan.send(tx).await;
+                Self::write_ssh_message_with_closure(message, sshwr, async {
+                    let _ = mdchan.send(ResponseType::SSH(rx)).await;
+                    self.ssh_entries.fetch_add(1, Ordering::AcqRel);
+                })
+                .await?;
             }
         };
         Ok(())
@@ -455,21 +571,11 @@ impl Proxy {
         }
     }
 
-    async fn proxy_ssh_message(
-        &self,
-        src: &Mutex<UnixStream>,
-        dest: &Mutex<UnixStream>,
-    ) -> Result<(), Error> {
-        let m = Self::read_ssh_message(src).await?;
-        Self::write_ssh_message(&m, dest).await?;
-        Ok(())
-    }
-
     async fn write_ssh_message_of_type(
         &self,
         kind: MessageKind,
         message: &[u8],
-        sock: &Mutex<UnixStream>,
+        sock: &Mutex<OwnedWriteHalf>,
     ) -> Result<(), Error> {
         let mut buf = [0u8; 5 + 4 + Self::EXTENSION.len()];
         let bkind = kind as u8;
@@ -493,16 +599,34 @@ impl Proxy {
 
     async fn write_ssh_message(
         message: &SSHMessage,
-        sock: &Mutex<UnixStream>,
+        sock: &Mutex<OwnedWriteHalf>,
     ) -> Result<(), Error> {
         let mut ssh = sock.lock().await;
         message.write_full(&mut *ssh).await?;
         Ok(())
     }
 
-    async fn read_ssh_message(sock: &Mutex<UnixStream>) -> Result<SSHMessage, Error> {
-        use tokio::io::AsyncReadExt;
+    async fn write_ssh_message_with_closure<F: std::future::Future<Output = ()>>(
+        message: &SSHMessage,
+        sock: &Mutex<OwnedWriteHalf>,
+        f: F,
+    ) -> Result<(), Error> {
         let mut ssh = sock.lock().await;
+        message.write_full(&mut *ssh).await?;
+        f.await;
+        Ok(())
+    }
+
+    async fn read_ssh_message<T: AsyncReadExt + Unpin>(
+        sock: &Mutex<T>,
+    ) -> Result<SSHMessage, Error> {
+        let mut ssh = sock.lock().await;
+        Self::read_ssh_message_unlocked(&mut *ssh).await
+    }
+
+    async fn read_ssh_message_unlocked<T: AsyncReadExt + Unpin>(
+        ssh: &mut T,
+    ) -> Result<SSHMessage, Error> {
         let mut buf = [0u8; 5];
         ssh.read_exact(&mut buf).await?;
         let len = u32::from_be_bytes(buf[0..4].try_into().unwrap());
@@ -518,8 +642,10 @@ impl Proxy {
         Ok(msg)
     }
 
-    async fn read_borrowed_ssh_message<'a>(sock: &Mutex<UnixStream>, v: &'a mut Vec<u8>) -> Result<BorrowedSSHMessage<'a>, Error> {
-        use tokio::io::AsyncReadExt;
+    async fn read_borrowed_ssh_message<'a>(
+        sock: &Mutex<UnixStream>,
+        v: &'a mut Vec<u8>,
+    ) -> Result<BorrowedSSHMessage<'a>, Error> {
         let mut ssh = sock.lock().await;
         let mut buf = [0u8; 5];
         ssh.read_exact(&mut buf).await?;
@@ -533,7 +659,9 @@ impl Proxy {
             v.reserve(datalen - v.capacity());
         }
         {
-            let slice = unsafe { std::mem::transmute::<_, &mut [u8]>(&mut v.spare_capacity_mut()[0..datalen]) };
+            let slice = unsafe {
+                std::mem::transmute::<_, &mut [u8]>(&mut v.spare_capacity_mut()[0..datalen])
+            };
             ssh.read_exact(slice).await?;
             unsafe { v.set_len(datalen) };
         }

--- a/lawn/src/ssh_proxy.rs
+++ b/lawn/src/ssh_proxy.rs
@@ -247,6 +247,7 @@ impl Proxy {
         multiplex: std::os::unix::net::UnixStream,
     ) -> Result<std::os::unix::net::UnixStream, Error> {
         let logger = config.logger();
+        let _ = multiplex.set_nonblocking(true);
         let sock = UnixStream::from_std(multiplex).unwrap();
         let (mrd, mwr) = sock.into_split();
         let mwr = Mutex::new(mwr);
@@ -268,7 +269,9 @@ impl Proxy {
         trace!(logger, "SSH client probe: ok");
         let mrd = mrd.into_inner();
         let mwr = mwr.into_inner();
-        Ok(mrd.reunite(mwr).unwrap().into_std().unwrap())
+        let std = mrd.reunite(mwr).unwrap().into_std().unwrap();
+        let _ = std.set_nonblocking(false);
+        Ok(std)
     }
 
     /// Runs a client to completion.

--- a/lawn/src/ssh_proxy.rs
+++ b/lawn/src/ssh_proxy.rs
@@ -321,6 +321,7 @@ impl Proxy {
                         }
                         Ok(n) => {
                             let _ = self.send_client_message(Some(&buf[0..n])).await;
+                            let _ = self.send_client_message(None).await;
                         }
                         Err(e) if e.kind() == io::ErrorKind::ConnectionReset => {
                             return Ok(());
@@ -419,7 +420,7 @@ impl Proxy {
             };
             match item {
                 ResponseType::Lawn | ResponseType::LawnPing => {
-                    if count == 0 && item == ResponseType::Lawn {
+                    if count == 0 {
                         // There's no other Lawn message in the queue.  Let's wait a bit to see if one
                         // comes in.
                         let _ =


### PR DESCRIPTION
The performance of the SSH proxy is currently quite underwhelming, which makes using `lawn proxy` difficult for any sort of major throughput.  Let's make some improvements that take performance from less than 200 KiB/s to as high as 266 MiB/s on a local system, which is more than a 1000× performance improvement.