### PR TITLE
Implement querying for placement of credentials

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -320,6 +320,8 @@ dependencies = [
  "libc",
  "num-derive",
  "num-traits",
+ "rand",
+ "rand_chacha",
  "serde",
  "serde_cbor",
  "serde_json",
@@ -531,6 +533,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e280fbe77cc62c91527259e9442153f4688736748d24660126286329742b4c6c"
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -546,6 +554,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5907a1b7c277254a8b15170f6e7c97cfa60ee7872a3217663bb81151e48184bb"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,6 +31,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "base64"
+version = "0.21.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35636a1494ede3b646cc98f74f8e62c773a38a659ebc777a2cf26b9b74171df9"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -299,6 +305,7 @@ name = "lawn"
 version = "0.3.0"
 dependencies = [
  "async-trait",
+ "base64",
  "blake2",
  "bytes",
  "clap",

--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ clean:
 	$(RM) -fr doc/man/*.1 doc/man/*.1.gz
 	$(RM) lawn/README.adoc
 
-test:
+test: all
 	cargo test $(FEATURE_ARG)
 
 test-integration: all

--- a/lawn-9p/src/backend/libc.rs
+++ b/lawn-9p/src/backend/libc.rs
@@ -1044,8 +1044,8 @@ mod tests {
         FileType, LinuxFileType, LinuxOpenMode, LinuxStatValidity, Metadata, PlainStat,
         ProtocolVersion, SimpleOpenMode, Tag, UnixStat, FID,
     };
+    use lawn_constants::error::{Error, ExtendedError};
     use lawn_constants::logger::{LogFormat, LogLevel};
-    use lawn_constants::Error;
     use lawn_fs::auth::{AuthenticationInfo, Authenticator, AuthenticatorHandle};
     use lawn_fs::backend as fsbackend;
     use std::collections::HashSet;
@@ -1138,6 +1138,10 @@ mod tests {
         fn trace(&self, msg: &str) {
             eprintln!("{}", msg);
         }
+        fn script_message(&self, _tag: Option<&[u8]>, _msg: &[&[u8]]) {}
+        fn script_error(&self, _tag: Option<&[u8]>, _err: &dyn ExtendedError) {}
+        fn serialized(&self, _msg: &[u8]) {}
+        fn serialized_error(&self, _msg: &dyn ExtendedError) {}
     }
 
     type Server = LibcBackend;

--- a/lawn-constants/src/logger.rs
+++ b/lawn-constants/src/logger.rs
@@ -1,3 +1,4 @@
+use crate::error::ExtendedError;
 use std::fmt;
 use std::sync::Arc;
 
@@ -29,6 +30,10 @@ pub trait Logger {
     fn info(&self, msg: &str);
     fn debug(&self, msg: &str);
     fn trace(&self, msg: &str);
+    fn script_message(&self, tag: Option<&[u8]>, msg: &[&[u8]]);
+    fn script_error(&self, tag: Option<&[u8]>, err: &dyn ExtendedError);
+    fn serialized(&self, msg: &[u8]);
+    fn serialized_error(&self, msg: &dyn ExtendedError);
 }
 
 impl<T: Logger> Logger for Arc<T> {
@@ -62,6 +67,22 @@ impl<T: Logger> Logger for Arc<T> {
 
     fn trace(&self, msg: &str) {
         self.as_ref().trace(msg);
+    }
+
+    fn script_message(&self, tag: Option<&[u8]>, msg: &[&[u8]]) {
+        self.as_ref().script_message(tag, msg);
+    }
+
+    fn script_error(&self, tag: Option<&[u8]>, err: &dyn ExtendedError) {
+        self.as_ref().script_error(tag, err);
+    }
+
+    fn serialized(&self, msg: &[u8]) {
+        self.as_ref().serialized(msg);
+    }
+
+    fn serialized_error(&self, msg: &dyn ExtendedError) {
+        self.as_ref().serialized_error(msg);
     }
 }
 

--- a/lawn-fs/src/backend/libc.rs
+++ b/lawn-fs/src/backend/libc.rs
@@ -1628,8 +1628,8 @@ mod tests {
     use crate::backend::{
         Backend, FileType, Metadata, OpenMode, Plan9Type, ProtocolType, StatValidity, Tag, FID,
     };
+    use lawn_constants::error::{Error, ExtendedError};
     use lawn_constants::logger::{LogFormat, LogLevel};
-    use lawn_constants::Error;
     use rustix::fd::{AsFd, OwnedFd};
     use std::collections::HashSet;
     use std::ffi::OsStr;
@@ -1706,6 +1706,10 @@ mod tests {
         fn trace(&self, msg: &str) {
             eprintln!("{}", msg);
         }
+        fn script_message(&self, _tag: Option<&[u8]>, _msg: &[&[u8]]) {}
+        fn script_error(&self, _tag: Option<&[u8]>, _err: &dyn ExtendedError) {}
+        fn serialized(&self, _msg: &[u8]) {}
+        fn serialized_error(&self, _msg: &dyn ExtendedError) {}
     }
 
     type Server = LibcBackend;

--- a/lawn-protocol/src/protocol/mod.rs
+++ b/lawn-protocol/src/protocol/mod.rs
@@ -306,6 +306,12 @@ pub enum MessageKind {
 
     /// Search store elements.
     SearchStoreElements = 0x0003000c,
+
+    /// Read a server context.
+    ReadServerContext = 0x00040000,
+
+    /// Write a server context.
+    WriteServerContext = 0x00040001,
 }
 
 #[derive(Debug, Hash, Eq, PartialEq, Ord, PartialOrd, Clone)]
@@ -319,6 +325,7 @@ pub enum Capability {
     ChannelClipboard,
     ExtensionAllocate,
     StoreCredential,
+    ContextTemplate,
     Other(Bytes, Option<Bytes>),
 }
 
@@ -390,6 +397,10 @@ impl From<Capability> for (Bytes, Option<Bytes>) {
                 (b"extension" as &[u8]).into(),
                 Some((b"allocate" as &[u8]).into()),
             ),
+            Capability::ContextTemplate => (
+                (b"context" as &[u8]).into(),
+                Some((b"template" as &[u8]).into()),
+            ),
             Capability::Other(name, subtype) => (name, subtype),
         }
     }
@@ -407,6 +418,7 @@ impl From<(&[u8], Option<&[u8]>)> for Capability {
             (b"channel", Some(b"clipboard")) => Capability::ChannelClipboard,
             (b"store", Some(b"credential")) => Capability::StoreCredential,
             (b"extension", Some(b"allocate")) => Capability::ExtensionAllocate,
+            (b"context", Some(b"template")) => Capability::ContextTemplate,
             (name, subtype) => {
                 Capability::Other(name.to_vec().into(), subtype.map(|s| s.to_vec().into()))
             }
@@ -1031,6 +1043,54 @@ pub struct KeyboardInteractiveAuthenticationRequest {
 #[derive(Serialize, Deserialize, Debug, Eq, PartialEq, Ord, PartialOrd, Clone)]
 pub struct KeyboardInteractiveAuthenticationResponse {
     pub responses: Vec<String>,
+}
+
+#[derive(Serialize, Deserialize, Eq, PartialEq, Ord, PartialOrd, Clone)]
+#[serde(rename_all = "kebab-case")]
+pub struct ReadServerContextRequest {
+    pub kind: String,
+    pub id: Option<Bytes>,
+    pub meta: Option<BTreeMap<Bytes, Value>>,
+}
+
+#[derive(Serialize, Deserialize, Eq, PartialEq, Ord, PartialOrd, Clone)]
+#[serde(rename_all = "kebab-case")]
+pub struct ReadServerContextResponse {
+    pub id: Option<Bytes>,
+    pub meta: Option<BTreeMap<Bytes, Value>>,
+}
+
+#[derive(Serialize, Deserialize, Eq, PartialEq, Ord, PartialOrd, Clone)]
+#[serde(rename_all = "kebab-case")]
+pub struct ReadServerContextResponseWithBody<T> {
+    pub id: Option<Bytes>,
+    pub meta: Option<BTreeMap<Bytes, Value>>,
+    pub body: Option<T>,
+}
+
+#[derive(Serialize, Deserialize, Eq, PartialEq, Ord, PartialOrd, Clone)]
+#[serde(rename_all = "kebab-case")]
+pub struct WriteServerContextRequest {
+    pub kind: String,
+    pub id: Option<Bytes>,
+    pub meta: Option<BTreeMap<Bytes, Value>>,
+}
+
+#[derive(Serialize, Deserialize, Eq, PartialEq, Ord, PartialOrd, Clone)]
+#[serde(rename_all = "kebab-case")]
+pub struct WriteServerContextResponseWithBody<T> {
+    pub id: Option<Bytes>,
+    pub meta: Option<BTreeMap<Bytes, Value>>,
+    pub body: Option<T>,
+}
+
+#[derive(Serialize, Deserialize, Eq, PartialEq, Ord, PartialOrd, Clone)]
+#[serde(rename_all = "kebab-case")]
+pub struct TemplateServerContextBody {
+    pub senv: Option<BTreeMap<Bytes, Bytes>>,
+    pub cenv: Option<BTreeMap<Bytes, Bytes>>,
+    pub ctxsenv: Option<BTreeMap<Bytes, Bytes>>,
+    pub args: Option<Vec<Bytes>>,
 }
 
 /// A message for the protocol.

--- a/lawn-protocol/src/protocol/mod.rs
+++ b/lawn-protocol/src/protocol/mod.rs
@@ -342,6 +342,7 @@ impl Capability {
             Self::ChannelSFTP,
             Self::ExtensionAllocate,
             Self::StoreCredential,
+            Self::ContextTemplate,
         ]
         .iter()
         .cloned()
@@ -360,6 +361,7 @@ impl Capability {
                 | Self::ChannelSFTP
                 | Self::ExtensionAllocate
                 | Self::StoreCredential
+                | Self::ContextTemplate
         )
     }
 }

--- a/lawn-protocol/src/protocol/mod.rs
+++ b/lawn-protocol/src/protocol/mod.rs
@@ -1093,6 +1093,16 @@ pub struct TemplateServerContextBody {
     pub args: Option<Vec<Bytes>>,
 }
 
+#[derive(Serialize, Deserialize, Eq, PartialEq, Ord, PartialOrd, Clone)]
+#[serde(rename_all = "kebab-case")]
+pub struct TemplateServerContextBodyWithBody<T> {
+    pub senv: Option<BTreeMap<Bytes, Bytes>>,
+    pub cenv: Option<BTreeMap<Bytes, Bytes>>,
+    pub ctxsenv: Option<BTreeMap<Bytes, Bytes>>,
+    pub args: Option<Vec<Bytes>>,
+    pub body: Option<T>,
+}
+
 /// A message for the protocol.
 #[derive(Clone, Debug)]
 pub struct Message {

--- a/lawn-sftp/src/backend.rs
+++ b/lawn-sftp/src/backend.rs
@@ -847,8 +847,8 @@ mod tests {
         ProtocolTag, ProtocolVersion, Tag,
     };
     use crate::server::implementation::ProtocolData;
+    use lawn_constants::error::{Error, ExtendedError};
     use lawn_constants::logger::{LogFormat, LogLevel};
-    use lawn_constants::Error;
     use lawn_fs::auth::{AuthenticationInfo, Authenticator, AuthenticatorHandle};
     use std::collections::{BTreeMap, BTreeSet, HashSet};
     use std::fs;
@@ -943,6 +943,10 @@ mod tests {
         fn trace(&self, msg: &str) {
             eprintln!("{}", msg);
         }
+        fn script_message(&self, _tag: Option<&[u8]>, _msg: &[&[u8]]) {}
+        fn script_error(&self, _tag: Option<&[u8]>, _err: &dyn ExtendedError) {}
+        fn serialized(&self, _msg: &[u8]) {}
+        fn serialized_error(&self, _msg: &dyn ExtendedError) {}
     }
 
     type Server = Backend;

--- a/lawn/Cargo.toml
+++ b/lawn/Cargo.toml
@@ -21,6 +21,7 @@ path = "src/main.rs"
 
 [dependencies]
 async-trait = "= 0.1.66"
+base64 = "0.21"
 blake2 = "0.10"
 bytes = "1"
 clap = { version = "2.32", default-features = false }

--- a/lawn/Cargo.toml
+++ b/lawn/Cargo.toml
@@ -37,6 +37,8 @@ lawn-9p = { path = "../lawn-9p", version = "0.3.0", features = ["unix"] }
 lawn-fs = { path = "../lawn-fs", version = "0.3.0", features = ["unix"] }
 lawn-protocol = { path = "../lawn-protocol", version = "0.3.0", features = ["async"] }
 lawn-sftp = { path = "../lawn-sftp", version = "0.3.0" }
+rand = "0.8"
+rand_chacha = "0.3"
 subtle = "2"
 tokio = { version = "1", features = [ "io-std", "macros", "net", "process", "rt", "rt-multi-thread", "signal", "time" ] }
 tokio-pipe = "0.2"

--- a/lawn/src/channel.rs
+++ b/lawn/src/channel.rs
@@ -70,7 +70,7 @@ impl ChannelManager {
 
     pub fn get(&self, id: ChannelID) -> Option<Arc<dyn Channel + Send + Sync>> {
         let g = self.map.read().unwrap();
-        g.get(&id).map(Arc::clone)
+        g.get(&id).cloned()
     }
 
     pub async fn ping_channels(&self) {

--- a/lawn/src/client.rs
+++ b/lawn/src/client.rs
@@ -331,6 +331,37 @@ impl Connection {
         }
     }
 
+    pub async fn read_template_context(
+        &self,
+        id: Bytes,
+    ) -> Result<Option<protocol::TemplateServerContextBody>, Error> {
+        let req = protocol::ReadServerContextRequest {
+            kind: "template".into(),
+            id: Some(id),
+            meta: None,
+        };
+        match self
+            .send_message_simple::<_, protocol::ReadServerContextResponseWithBody<protocol::TemplateServerContextBody>>(MessageKind::ReadServerContext,
+                Some(&req))
+            .await
+        {
+            Ok(Some(resp)) => {
+                match resp.body {
+                    Some(body) => Ok(Some(body)),
+                    None => Err(Error::new(ErrorKind::MissingResponse)),
+                }
+            }
+            Ok(None) => Err(Error::new(ErrorKind::MissingResponse)),
+            Err(e) => {
+                match protocol::Error::try_from(e) {
+                    Ok(protocol::Error{ code: protocol::ResponseCode::NotFound, .. }) => Ok(None),
+                    Ok(e) => Err(handler::Error::ProtocolError(e).into()),
+                    Err(e) => Err(e.0.into()),
+                }
+            }
+        }
+    }
+
     pub async fn run_clipboard<
         I: AsyncReadExt + Unpin + Send + 'static,
         O: AsyncWriteExt + Unpin + Send + 'static,

--- a/lawn/src/config.rs
+++ b/lawn/src/config.rs
@@ -1,6 +1,7 @@
 #![allow(dead_code)]
 use crate::error::{Error, ErrorKind};
 use crate::serializer::script::ScriptEncoder;
+use crate::socket::LawnSocketData;
 use crate::template::{Template, TemplateContext};
 use bytes::{Bytes, BytesMut};
 use format_bytes::format_bytes;
@@ -108,6 +109,7 @@ struct ConfigData {
     clipboard_enabled: Option<bool>,
     capability: BTreeSet<Capability>,
     credential_backends: Option<Vec<CredentialBackend>>,
+    socket_data: Option<LawnSocketData>,
 }
 
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -268,6 +270,7 @@ impl ConfigBuilder {
                 clipboard_enabled: None,
                 capability: self.capabilities.unwrap_or_else(Capability::implemented),
                 credential_backends: None,
+                socket_data: None,
             }),
             env_vars,
             prng,
@@ -369,6 +372,7 @@ impl Config {
                 clipboard_enabled: None,
                 capability: Capability::implemented(),
                 credential_backends: None,
+                socket_data: None,
             }),
             env_vars: Arc::new(
                 env_iter()
@@ -382,6 +386,12 @@ impl Config {
             ))),
             template_contexts: Arc::new(RwLock::new(BTreeMap::new())),
         })
+    }
+
+    pub fn set_socket_data(&self, data: LawnSocketData) {
+        trace!(self.logger(), "config: setting socket data: {:?}", &data);
+        let mut g = self.data.write().unwrap();
+        g.socket_data = Some(data);
     }
 
     pub fn prng(&self) -> Arc<Mutex<dyn RNG + Send + Sync>> {

--- a/lawn/src/config.rs
+++ b/lawn/src/config.rs
@@ -1240,6 +1240,14 @@ impl<'a> ConfigValue<'a> {
                 )
             }));
         }
+        if let Some(ctxsenv) = &self.context.ctxsenv {
+            cmd.envs(ctxsenv.iter().map(|(k, v)| {
+                (
+                    OsString::from_vec(k.to_vec()),
+                    OsString::from_vec(v.to_vec()),
+                )
+            }));
+        }
         cmd.current_dir("/");
         cmd
     }

--- a/lawn/src/config.rs
+++ b/lawn/src/config.rs
@@ -401,6 +401,8 @@ impl Config {
             cenv,
             args,
             ctxsenv: None,
+            kind: None,
+            extra: None,
         });
         {
             let mut g = self.template_contexts.write().unwrap();

--- a/lawn/src/credential.rs
+++ b/lawn/src/credential.rs
@@ -640,7 +640,7 @@ impl CredentialHandle for CredentialDirectoryHandle {
             .await?;
         let id = resp
             .and_then(|r| r.first()?.id)
-            .ok_or(CredentialError::UnsupportedSerialization)?;
+            .ok_or(CredentialError::NotFound)?;
         let req = DeleteStoreElementRequest {
             id: self.store_id,
             selector: StoreSelector::ID(id),

--- a/lawn/src/credential.rs
+++ b/lawn/src/credential.rs
@@ -1581,7 +1581,7 @@ impl CredentialRequest {
         self.service.matches_string(cred.service.as_deref()) &&
         self.title.matches_string(cred.title.as_deref()) &&
         self.description.matches_string(cred.description.as_deref()) &&
-        self.id.matches_string(cred.service.as_deref()) &&
+        self.id.matches_bytes(Some(&cred.id)) &&
         self.extra.iter().all(|(k, v)| {
             let val = cred.extra.get(k).unwrap_or(&Value::Null);
             v.matches_value(val)

--- a/lawn/src/error/mod.rs
+++ b/lawn/src/error/mod.rs
@@ -108,6 +108,16 @@ impl From<handler::Error> for Error {
     }
 }
 
+impl From<crate::socket::UnknownSocketKind> for Error {
+    fn from(err: crate::socket::UnknownSocketKind) -> Error {
+        Error {
+            kind: ErrorKind::SocketConnectionFailure,
+            message: None,
+            cause: Some(err.into()),
+        }
+    }
+}
+
 impl From<Error> for i32 {
     fn from(e: Error) -> i32 {
         e.kind.into()

--- a/lawn/src/error/mod.rs
+++ b/lawn/src/error/mod.rs
@@ -6,6 +6,8 @@ use std::fmt;
 use std::fmt::{Debug, Display};
 use std::io;
 
+pub use lawn_constants::error::ExtendedError;
+
 #[derive(Debug)]
 pub struct Error {
     kind: ErrorKind,
@@ -143,20 +145,6 @@ impl From<crate::credential::CredentialError> for Error {
             }
         }
     }
-}
-
-/// A trait to allow logging and scripting of error values.
-pub trait ExtendedError {
-    /// The types of errors.
-    ///
-    /// This provides a list of string error types that classify this error.  For example, a
-    /// credential error that wraps an I/O error might indicate `["credential-error", "io-error"].
-    fn error_types(&self) -> Cow<'static, [Cow<'static, str>]>;
-    /// The tag of an error.
-    ///
-    /// This tag represents the error as a simple dash-divided string that indicates this specific
-    /// error.  This will usually be a kebab-case version of the error kind.
-    fn error_tag(&self) -> Cow<'static, str>;
 }
 
 #[derive(Debug)]

--- a/lawn/src/main.rs
+++ b/lawn/src/main.rs
@@ -40,6 +40,7 @@ mod server;
 mod socket;
 mod ssh_proxy;
 mod store;
+mod subcommands;
 mod task;
 mod template;
 #[cfg(not(miri))]
@@ -525,6 +526,7 @@ fn dispatch_query(
 ) -> Result<(), Error> {
     match m.subcommand() {
         ("test-connection", Some(m)) => dispatch_query_test_connection(config, main, m),
+        ("context", Some(m)) => subcommands::query::dispatch_query_context(config, main, m),
         _ => Err(Error::new(ErrorKind::Unimplemented)),
     }
 }
@@ -890,7 +892,20 @@ fn dispatch(verbosity: &mut i32, handled: &mut bool) -> Result<(), Error> {
         .arg(Arg::with_name("socket").long("socket").takes_value(true).help("Specify the path to the Lawn socket"))
         .arg(Arg::with_name("no-detach").long("no-detach").help("Do not detach from the terminal when starting a server"))
         .subcommand(App::new("server").about("Start a server on the root machine"))
-        .subcommand(App::new("query").about("Query information about Lawn").subcommand(App::new("test-connection").about("Test that a connection can be made and is basically functional")))
+        .subcommand(
+            App::new("query")
+            .about("Query information about Lawn")
+            .subcommand(
+                App::new("test-connection")
+                .about("Test that a connection can be made and is basically functional"))
+            .subcommand(
+                App::new("context")
+                .about("Query information about the current context")
+                .arg(Arg::with_name("type").long("type").help("Specify the type of context (template)"))
+                .arg(Arg::with_name("list").long("list").help("List context data"))
+                .arg(Arg::with_name("format").long("format").takes_value(true).help("Specify the format pattern"))
+                .arg(Arg::with_name("pattern-type").long("pattern-type").takes_value(true).help("Specify the format pattern type (template)")),
+        ))
         .subcommand(
             App::new("clip")
                 .about("Copy to and paste from the clipboard")

--- a/lawn/src/main.rs
+++ b/lawn/src/main.rs
@@ -166,11 +166,15 @@ fn find_or_autostart_server(
     config: Arc<config::Config>,
 ) -> Result<LawnSocket, Error> {
     if let Some(socket) = find_server_socket(handle, socket, config.clone()) {
+        config.set_socket_data(socket.socket_data().clone());
         return Ok(socket);
     }
     autospawn_server(config.clone())?;
-    match find_server_socket(handle, socket, config) {
-        Some(s) => Ok(s),
+    match find_server_socket(handle, socket, config.clone()) {
+        Some(s) => {
+            config.set_socket_data(s.socket_data().clone());
+            Ok(s)
+        }
         None => Err(Error::new(ErrorKind::SocketConnectionFailure)),
     }
 }

--- a/lawn/src/serializer/script.rs
+++ b/lawn/src/serializer/script.rs
@@ -18,6 +18,7 @@
 /// includes the string `err`, includes a colon-separated set of error types (classes of error, if
 /// you will), a string error tag (representing the specific error), and a string error message.
 use bytes::Bytes;
+use format_bytes::format_bytes;
 use std::borrow::Cow;
 use std::convert::{TryFrom, TryInto};
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -145,9 +146,17 @@ impl Encodable for Vec<u8> {
 }
 
 impl Encodable for Bytes {
-    // TODO: encode properly.
     fn encode(&self) -> Cow<'_, [u8]> {
-        Cow::Borrowed(self.as_ref())
+        Cow::Owned(ScriptEncoder::encode_bytes(self.as_ref()))
+    }
+}
+
+impl<T: Encodable> Encodable for Option<T> {
+    fn encode(&self) -> Cow<'_, [u8]> {
+        match self {
+            Some(obj) => Cow::Owned(format_bytes!(b"@{}", obj.encode())),
+            None => Cow::Borrowed(b"nil".as_slice()),
+        }
     }
 }
 

--- a/lawn/src/serializer/script.rs
+++ b/lawn/src/serializer/script.rs
@@ -85,7 +85,11 @@ impl ScriptEncoder {
                     buf = [b'%', OFFSET[(b >> 4) as usize], OFFSET[(b & 0xf) as usize]];
                     &buf
                 }
-                b'%' | b' ' => {
+                // Percent and space are necessary.  Encode + so that CGI-based encoders, which
+                // decode + as space, will be able to handle this properly.  Encode backslash so
+                // that users can convert % to \x and print it with a suitable version of
+                // printf(1) or a scripting language.
+                b'%' | b' ' | b'+' | b'\\' => {
                     buf = [b'%', OFFSET[(b >> 4) as usize], OFFSET[(b & 0xf) as usize]];
                     &buf
                 }

--- a/lawn/src/socket.rs
+++ b/lawn/src/socket.rs
@@ -1,0 +1,244 @@
+use crate::config::Config;
+use crate::error::{Error, ErrorKind};
+use crate::ssh_proxy;
+use lawn_constants::logger::AsLogStr;
+use std::ffi::{OsStr, OsString};
+use std::fmt;
+use std::os::unix::ffi::OsStrExt;
+use std::os::unix::net::UnixStream;
+use std::path::Path;
+use std::str::FromStr;
+use std::sync::Arc;
+use tokio::runtime::Handle;
+
+#[derive(PartialEq, Eq, Copy, Clone, Debug, Hash)]
+pub enum LawnSocketKind {
+    Lawn,
+    SSHProxy,
+}
+
+impl fmt::Display for LawnSocketKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            LawnSocketKind::Lawn => write!(f, "Lawn socket"),
+            LawnSocketKind::SSHProxy => write!(f, "SSH proxy socket"),
+        }
+    }
+}
+
+impl FromStr for LawnSocketKind {
+    type Err = UnknownSocketKind;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "lawn" => Ok(LawnSocketKind::Lawn),
+            "ssh" => Ok(LawnSocketKind::SSHProxy),
+            _ => Err(UnknownSocketKind(s.into())),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct UnknownSocketKind(String);
+
+impl fmt::Display for UnknownSocketKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "unknown socket kind: {}", self.0)
+    }
+}
+
+impl std::error::Error for UnknownSocketKind {}
+
+pub struct LawnSocketDiscoverer<'a> {
+    config: Arc<Config>,
+    handle: &'a Handle,
+}
+
+impl<'a> LawnSocketDiscoverer<'a> {
+    pub fn new(config: Arc<Config>, handle: &'a Handle) -> Self {
+        Self { config, handle }
+    }
+
+    pub fn socket_from_path(&self, path: &OsStr) -> Option<LawnSocket> {
+        let logger = self.config.logger();
+        debug!(
+            logger,
+            "trying specified socket {}",
+            path.as_bytes().as_log_str()
+        );
+        self.socket(LawnSocketKind::Lawn, path)
+    }
+
+    pub fn autodiscover(&self, prune: bool) -> Option<LawnSocket> {
+        let logger = self.config.logger();
+        debug!(logger, "performing socket autodiscovery");
+        let senv = self.config.template_context(None, None).senv.unwrap();
+        if let Some(path) = senv.get(b"SSH_AUTH_SOCK" as &[u8]) {
+            debug!(logger, "trying SSH socket {}", path.as_ref().as_log_str());
+            let path = OsStr::from_bytes(&path);
+            match UnixStream::connect(path) {
+                Ok(sock) => {
+                    let log = logger.clone();
+                    let cfg = self.config.clone();
+                    let res = self.handle.block_on(async move {
+                        debug!(log, "SSH socket: performing client probe");
+                        ssh_proxy::Proxy::client_probe(cfg.clone(), sock).await
+                    });
+                    match res {
+                        Ok(sock) => {
+                            return Some(LawnSocket {
+                                kind: LawnSocketKind::SSHProxy,
+                                config: self.config.clone(),
+                                socket: Some(sock),
+                                lawn_socket: None,
+                                path: path.to_owned(),
+                            });
+                        }
+                        Err(_) => {
+                            debug!(logger, "failed to connect to SSH socket");
+                        }
+                    }
+                }
+                Err(e) => {
+                    debug!(logger, "SSH socket: failed to connect: {}", e);
+                }
+            }
+        }
+        let mut wanted = None;
+        for p in self.config.sockets() {
+            match p.file_name() {
+                Some(file) => {
+                    if !file.as_bytes().starts_with(b"server") {
+                        continue;
+                    }
+                }
+                None => continue,
+            }
+            trace!(
+                logger,
+                "trying socket {}",
+                p.as_os_str().as_bytes().as_log_str()
+            );
+            match UnixStream::connect(&p) {
+                Ok(sock) => {
+                    debug!(
+                        logger,
+                        "successfully connected to socket {}",
+                        p.as_os_str().as_bytes().as_log_str(),
+                    );
+                    if wanted.is_none() {
+                        wanted = Some(LawnSocket {
+                            socket: Some(sock),
+                            path: p.as_os_str().to_owned(),
+                            kind: LawnSocketKind::Lawn,
+                            config: self.config.clone(),
+                            lawn_socket: None,
+                        });
+                    }
+                }
+                Err(e) => match wanted {
+                    Some(_) => {
+                        if prune {
+                            self.prune_socket(&p);
+                        }
+                    }
+                    None => {
+                        debug!(
+                            logger,
+                            "failed to connect to socket {}: {}",
+                            p.as_os_str().as_bytes().as_log_str(),
+                            e
+                        );
+                        if prune {
+                            self.prune_socket(&p);
+                        }
+                    }
+                },
+            }
+        }
+        wanted
+    }
+
+    fn prune_socket(&self, path: &Path) {
+        let logger = self.config.logger();
+        trace!(
+            logger,
+            "autopruning socket {}",
+            path.as_os_str().as_bytes().as_log_str()
+        );
+        let _ = std::fs::remove_file(path);
+    }
+
+    fn socket(&self, kind: LawnSocketKind, path: &OsStr) -> Option<LawnSocket> {
+        match UnixStream::connect(path) {
+            Ok(sock) => Some(LawnSocket {
+                path: path.to_owned(),
+                kind,
+                socket: Some(sock),
+                config: self.config.clone(),
+                lawn_socket: None,
+            }),
+            Err(_) => None,
+        }
+    }
+}
+
+pub struct LawnSocket {
+    path: OsString,
+    kind: LawnSocketKind,
+    socket: Option<UnixStream>,
+    config: Arc<Config>,
+    lawn_socket: Option<UnixStream>,
+}
+
+impl LawnSocket {
+    pub fn spawn_proxies(&mut self, handle: &Handle) -> Result<(), Error> {
+        if self.kind != LawnSocketKind::SSHProxy {
+            return Ok(());
+        }
+        let config = self.config.clone();
+        let _eg = handle.enter();
+        let (sa, sb) = tokio::net::UnixStream::pair().unwrap();
+        let socket = match self.socket.take() {
+            Some(socket) => socket,
+            None => {
+                return Err(Error::new_with_message(
+                    ErrorKind::SocketConnectionFailure,
+                    "missing socket for proxy",
+                ))
+            }
+        };
+        let _ = socket.set_nonblocking(true);
+        tokio::spawn(async {
+            let p = ssh_proxy::Proxy::new(
+                config,
+                None,
+                sa,
+                tokio::net::UnixStream::from_std(socket).unwrap(),
+            );
+            let _ = p.run_client().await;
+        });
+        self.lawn_socket = Some(sb.into_std().unwrap());
+        Ok(())
+    }
+
+    pub fn lawn_socket(&mut self) -> Option<UnixStream> {
+        if let Some(s) = self.lawn_socket.take() {
+            return Some(s);
+        }
+        if self.kind == LawnSocketKind::Lawn {
+            if let Some(s) = self.socket.take() {
+                return Some(s);
+            }
+        }
+        None
+    }
+
+    pub fn path(&self) -> &OsStr {
+        &self.path
+    }
+
+    pub fn kind(&self) -> LawnSocketKind {
+        self.kind
+    }
+}

--- a/lawn/src/socket.rs
+++ b/lawn/src/socket.rs
@@ -65,7 +65,7 @@ pub struct LawnSocketData {
     path: Bytes,
     #[serde(rename = "ctx")]
     #[serde(skip_serializing_if = "Option::is_none")]
-    context: Option<Bytes>,
+    pub context: Option<Bytes>,
     #[serde(rename = "auth")]
     #[serde(skip_serializing_if = "Option::is_none")]
     auth: Option<Bytes>,
@@ -75,6 +75,29 @@ pub struct LawnSocketData {
     #[serde(rename = "pass")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pass: Option<Bytes>,
+}
+
+impl LawnSocketData {
+    pub fn new(kind: LawnSocketKind, path: Bytes) -> Self {
+        Self {
+            kind,
+            path,
+            context: None,
+            auth: None,
+            username: None,
+            pass: None,
+        }
+    }
+
+    pub fn generate_env(&self) -> Bytes {
+        let mut v = b"v0:c:".to_vec();
+        v.extend(
+            URL_SAFE_NO_PAD
+                .encode(serde_cbor::to_vec(&self).unwrap())
+                .as_bytes(),
+        );
+        v.into()
+    }
 }
 
 pub struct LawnSocketDiscoverer<'a> {
@@ -410,12 +433,20 @@ impl LawnSocket {
         None
     }
 
+    pub fn socket_data(&self) -> &LawnSocketData {
+        &self.data
+    }
+
     pub fn path(&self) -> &OsStr {
         OsStr::from_bytes(&self.data.path)
     }
 
     pub fn kind(&self) -> LawnSocketKind {
         self.data.kind
+    }
+
+    pub fn context(&self) -> Option<Bytes> {
+        self.data.context.clone()
     }
 }
 

--- a/lawn/src/socket.rs
+++ b/lawn/src/socket.rs
@@ -209,7 +209,8 @@ impl<'a> LawnSocketDiscoverer<'a> {
     pub fn autodiscover(&self, prune: bool) -> Option<LawnSocket> {
         let logger = self.config.logger();
         debug!(logger, "performing socket autodiscovery");
-        let senv = self.config.template_context(None, None).senv.unwrap();
+        let ctx = self.config.template_context(None, None);
+        let senv = ctx.senv.as_deref().unwrap();
         if let Some(value) = senv.get(b"LAWN" as &[u8]) {
             debug!(logger, "trying LAWN environment variable");
             if let Some(data) = self.socket_from_lawn_environment(&value) {

--- a/lawn/src/socket.rs
+++ b/lawn/src/socket.rs
@@ -232,8 +232,7 @@ impl<'a> LawnSocketDiscoverer<'a> {
     pub fn autodiscover(&self, prune: bool) -> Option<LawnSocket> {
         let logger = self.config.logger();
         debug!(logger, "performing socket autodiscovery");
-        let ctx = self.config.template_context(None, None);
-        let senv = ctx.senv.as_deref().unwrap();
+        let senv = self.config.env_vars();
         if let Some(value) = senv.get(b"LAWN" as &[u8]) {
             debug!(logger, "trying LAWN environment variable");
             if let Some(data) = self.socket_from_lawn_environment(&value) {

--- a/lawn/src/socket.rs
+++ b/lawn/src/socket.rs
@@ -56,7 +56,7 @@ impl fmt::Display for UnknownSocketKind {
 
 impl std::error::Error for UnknownSocketKind {}
 
-#[derive(Serialize, Deserialize, Default)]
+#[derive(Serialize, Deserialize, Default, Clone, Debug)]
 #[serde(rename_all = "kebab-case")]
 pub struct LawnSocketData {
     #[serde(rename = "sk")]

--- a/lawn/src/store.rs
+++ b/lawn/src/store.rs
@@ -201,22 +201,22 @@ pub trait StoreElement {
     fn update(
         self: Arc<Self>,
         meta: Option<&BTreeMap<Bytes, Value>>,
-        body: Option<&(dyn Any + 'static)>,
+        body: Option<&(dyn Any + Send + Sync + 'static)>,
     ) -> Result<(), protocol::Error>;
     fn meta(&self) -> Option<Cow<'_, BTreeMap<Bytes, Value>>>;
-    fn body(&self) -> Result<Option<Box<dyn Any + 'static>>, protocol::Error>;
+    fn body(&self) -> Result<Option<Box<dyn Any + Send + Sync + 'static>>, protocol::Error>;
     fn delete(&self) -> Result<(), protocol::Error>;
     fn create(
         self: Arc<Self>,
         path: Option<Bytes>,
         kind: &str,
         meta: Option<&BTreeMap<Bytes, Value>>,
-        body: Option<&dyn Any>,
+        body: Option<&(dyn Any + Send + Sync + 'static)>,
     ) -> Result<Arc<dyn StoreElement + Send + Sync>, protocol::Error>;
     fn search(
         self: Arc<Self>,
         kind: Option<Bytes>,
-        pattern: Option<&(dyn Any + 'static)>,
+        pattern: Option<&(dyn Any + Send + Sync + 'static)>,
         recurse: StoreSearchRecursionLevel,
     ) -> Result<
         Box<dyn Iterator<Item = Arc<dyn StoreElement + Send + Sync>> + Send + Sync>,
@@ -238,13 +238,13 @@ pub trait Store {
         path: Bytes,
         kind: &str,
         meta: Option<&BTreeMap<Bytes, Value>>,
-        body: Option<&(dyn Any + 'static)>,
+        body: Option<&(dyn Any + Send + Sync + 'static)>,
     ) -> Result<Arc<dyn StoreElement + Send + Sync>, protocol::Error>;
     fn search(
         &self,
         id: StoreSelectorID,
         kind: Option<Bytes>,
-        pattern: Option<&(dyn Any + 'static)>,
+        pattern: Option<&(dyn Any + Send + Sync + 'static)>,
         recurse: StoreSearchRecursionLevel,
     ) -> Result<
         Box<dyn Iterator<Item = Arc<dyn StoreElement + Send + Sync>> + Send + Sync>,

--- a/lawn/src/store.rs
+++ b/lawn/src/store.rs
@@ -41,7 +41,7 @@ impl StoreManager {
 
     pub fn get(&self, id: StoreID) -> Option<Arc<dyn Store + Send + Sync>> {
         let g = self.map.read().unwrap();
-        g.get(&id).map(Arc::clone)
+        g.get(&id).cloned()
     }
 }
 

--- a/lawn/src/store/credential/git.rs
+++ b/lawn/src/store/credential/git.rs
@@ -235,7 +235,7 @@ impl CommandCredentialBackend for GitCredentialBackend {
     fn read_body(
         self: Arc<Self>,
         _id: StoreSelectorID,
-    ) -> Result<Option<Box<dyn Any + 'static>>, protocol::Error> {
+    ) -> Result<Option<Box<dyn Any + Send + Sync + 'static>>, protocol::Error> {
         Err(ResponseCode::Unlistable.into())
     }
 }

--- a/lawn/src/store/credential/helpers.rs
+++ b/lawn/src/store/credential/helpers.rs
@@ -43,7 +43,7 @@ impl<
     fn search(
         self: Arc<Self>,
         kind: Option<Bytes>,
-        pattern: Option<&(dyn Any + 'static)>,
+        pattern: Option<&(dyn Any + Send + Sync + 'static)>,
         recurse: StoreSearchRecursionLevel,
     ) -> Result<
         Box<dyn Iterator<Item = Arc<dyn StoreElement + Send + Sync>> + Send + Sync>,
@@ -131,7 +131,7 @@ impl<T: Send + Sync, U: CommandCredentialBackend<Backend = T> + Sized + Send + S
     fn update(
         self: Arc<Self>,
         meta: Option<&BTreeMap<Bytes, Value>>,
-        body: Option<&(dyn Any + 'static)>,
+        body: Option<&(dyn Any + Send + Sync + 'static)>,
     ) -> Result<(), protocol::Error> {
         self.to_handle().update(meta, body)
     }
@@ -149,14 +149,14 @@ impl<T: Send + Sync, U: CommandCredentialBackend<Backend = T> + Sized + Send + S
         Some(Cow::Owned(map))
     }
 
-    fn body(&self) -> Result<Option<Box<dyn Any + 'static>>, protocol::Error> {
+    fn body(&self) -> Result<Option<Box<dyn Any + Send + Sync + 'static>>, protocol::Error> {
         Err(ResponseCode::NotSupported.into())
     }
 
     fn search(
         self: Arc<Self>,
         kind: Option<Bytes>,
-        pattern: Option<&(dyn Any + 'static)>,
+        pattern: Option<&(dyn Any + Send + Sync + 'static)>,
         recurse: StoreSearchRecursionLevel,
     ) -> Result<
         Box<dyn Iterator<Item = Arc<dyn StoreElement + Send + Sync>> + Send + Sync>,
@@ -170,7 +170,7 @@ impl<T: Send + Sync, U: CommandCredentialBackend<Backend = T> + Sized + Send + S
         path: Option<Bytes>,
         kind: &str,
         meta: Option<&BTreeMap<Bytes, Value>>,
-        body: Option<&(dyn Any + 'static)>,
+        body: Option<&(dyn Any + Send + Sync + 'static)>,
     ) -> Result<Arc<dyn StoreElement + Send + Sync>, protocol::Error> {
         self.to_handle().create(path, kind, meta, body)
     }
@@ -281,7 +281,7 @@ impl<
     fn update(
         self: Arc<Self>,
         _meta: Option<&BTreeMap<Bytes, Value>>,
-        body: Option<&dyn Any>,
+        body: Option<&(dyn Any + Send + Sync + 'static)>,
     ) -> Result<(), protocol::Error> {
         let logger = self.parent.clone().config().logger();
         match CredentialPathComponentType::from_path(self.path.clone()) {
@@ -361,7 +361,7 @@ impl<
         None
     }
 
-    fn body(&self) -> Result<Option<Box<dyn Any + 'static>>, protocol::Error> {
+    fn body(&self) -> Result<Option<Box<dyn Any + Send + Sync + 'static>>, protocol::Error> {
         match self.credential.lock().unwrap().as_ref() {
             Some(c) => {
                 let cse: CredentialStoreElement = c.into();
@@ -374,7 +374,7 @@ impl<
     fn search(
         self: Arc<Self>,
         kind: Option<Bytes>,
-        pattern: Option<&(dyn Any + 'static)>,
+        pattern: Option<&(dyn Any + Send + Sync + 'static)>,
         recurse: StoreSearchRecursionLevel,
     ) -> Result<
         Box<dyn Iterator<Item = Arc<dyn StoreElement + Send + Sync>> + Send + Sync>,
@@ -447,7 +447,7 @@ impl<
         path: Option<Bytes>,
         kind: &str,
         _meta: Option<&BTreeMap<Bytes, Value>>,
-        body: Option<&(dyn Any + 'static)>,
+        body: Option<&(dyn Any + Send + Sync + 'static)>,
     ) -> Result<Arc<dyn StoreElement + Send + Sync>, protocol::Error> {
         let logger = self.parent.clone().config().logger();
         trace!(
@@ -642,7 +642,7 @@ pub trait CommandCredentialBackend {
     fn read_body(
         self: Arc<Self>,
         id: StoreSelectorID,
-    ) -> Result<Option<Box<dyn Any + 'static>>, protocol::Error>;
+    ) -> Result<Option<Box<dyn Any + Send + Sync + 'static>>, protocol::Error>;
     fn create_directory(self: Arc<Self>, path: Bytes) -> Result<(), protocol::Error>;
 }
 

--- a/lawn/src/store/credential/memory.rs
+++ b/lawn/src/store/credential/memory.rs
@@ -901,7 +901,7 @@ impl CommandCredentialBackend for MemoryCredentialBackend {
     fn read_body(
         self: Arc<Self>,
         id: StoreSelectorID,
-    ) -> Result<Option<Box<dyn Any + 'static>>, protocol::Error> {
+    ) -> Result<Option<Box<dyn Any + Send + Sync + 'static>>, protocol::Error> {
         let vaults = self
             .vaults
             .vaults()

--- a/lawn/src/subcommands.rs
+++ b/lawn/src/subcommands.rs
@@ -1,0 +1,1 @@
+pub mod query;

--- a/lawn/src/subcommands/query.rs
+++ b/lawn/src/subcommands/query.rs
@@ -1,0 +1,288 @@
+use crate::client;
+use crate::config::{self, SerializedLogger};
+use crate::encoding::{escape, osstr};
+use crate::error::{Error, ErrorKind};
+use crate::serializer::script::ScriptEncoder;
+use crate::template::{self, Template, TemplateContext};
+use bytes::Bytes;
+use clap::ArgMatches;
+use format_bytes::format_bytes;
+use lawn_constants::logger::LogFormat;
+use lawn_constants::logger::Logger as LoggerTrait;
+use lawn_protocol::protocol::{CredentialStoreElement, TemplateServerContextBodyWithBody};
+use serde::Serialize;
+use std::borrow::Borrow;
+use std::sync::Arc;
+
+#[derive(Serialize)]
+#[serde(rename_all = "kebab-case")]
+struct TemplateContextResponse<'a, T> {
+    context: &'a TemplateServerContextBodyWithBody<T>,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "kebab-case")]
+struct TemplateContextFormatResponse {
+    data: Bytes,
+}
+
+fn format_template<T>(
+    ctx: TemplateServerContextBodyWithBody<T>,
+    pattern: &[u8],
+) -> Result<Bytes, template::Error> {
+    let ctx: TemplateContext = ctx.into();
+    Template::new(pattern).expand(&ctx)
+}
+
+pub fn dispatch_query_context(
+    config: Arc<config::Config>,
+    main: &ArgMatches,
+    m: &ArgMatches,
+) -> Result<(), Error> {
+    let logger = config.logger();
+    trace!(logger, "Starting runtime");
+    let runtime = crate::runtime();
+    let mut socket = crate::find_or_autostart_server(
+        runtime.handle(),
+        main.value_of_os("socket"),
+        config.clone(),
+    )?;
+    match m.value_of("type") {
+        Some("template") | None => (),
+        _ => {
+            return Err(Error::new_with_message(
+                ErrorKind::InvalidArgumentValue,
+                r#"invalid argument for --type (only "template" is allowed)"#,
+            ))
+        }
+    }
+    let pattern = match (m.is_present("list"), m.value_of("format")) {
+        (true, None) => None,
+        (false, Some(p)) => Some(p),
+        (true, Some(_)) => {
+            return Err(Error::new_with_message(
+                ErrorKind::IncompatibleArguments,
+                r"at least one of --list or --pattern is required",
+            ))
+        }
+        (_, _) => {
+            return Err(Error::new_with_message(
+                ErrorKind::IncompatibleArguments,
+                r"--list and --pattern are mutually exclusive",
+            ))
+        }
+    };
+    let ctxid = match socket.context() {
+        Some(ctx) => ctx,
+        None => return Err(Error::new_with_message(
+            ErrorKind::MissingContext,
+            "the LAWN environment variable must be set and have a context to use this subcommand",
+        )),
+    };
+    runtime.block_on(async {
+        let client = client::Client::new(config);
+        debug!(
+            logger,
+            "Connecting to {} {}",
+            socket.kind(),
+            escape(osstr(socket.path()))
+        );
+        let conn = client
+            .connect_to_socket(socket.lawn_socket().unwrap(), false)
+            .await?;
+        let _ = conn.negotiate_default_version().await;
+        let _ = conn.auth_external().await;
+
+        let (kind, ctx) = match conn
+            .read_template_context::<CredentialStoreElement>(ctxid)
+            .await
+        {
+            Ok(Some(ctx)) => ctx,
+            Ok(None) => {
+                return Err(Error::new_with_message(
+                    ErrorKind::MissingContext,
+                    "the LAWN environment variable contains an invalid context",
+                ))
+            }
+            Err(e) => return Err(e),
+        };
+        trace!(logger, "query context: found context of kind {:?}", kind);
+        // If pattern is None, this is list mode; otherwise, it's pattern mode.
+        match (pattern, logger.format()) {
+            (None, LogFormat::CBOR) | (None, LogFormat::JSON) => {
+                let body = TemplateContextResponse { context: &ctx };
+                logger.serialized_message(&body);
+                Ok(())
+            }
+            (None, LogFormat::Scriptable) => {
+                let tag = b"_a01";
+                if let Some(args) = ctx.args {
+                    for arg in args {
+                        logger.script_message(Some(tag), &[b"context", b"args", &arg]);
+                    }
+                }
+                let pairs = &[
+                    (&ctx.senv, "senv"),
+                    (&ctx.cenv, "cenv"),
+                    (&ctx.ctxsenv, "ctxsenv"),
+                ];
+                for (data, kind) in pairs {
+                    if let Some(args) = data {
+                        for (k, v) in args {
+                            logger.script_message(Some(tag), &[b"context", kind.as_bytes(), k, v]);
+                        }
+                    }
+                }
+                if let (Some("credential"), Some(body)) = (kind.as_deref(), ctx.body) {
+                    logger
+                        .script_message(Some(tag), &[b"context", b"template-type", b"credential"]);
+                    let se = ScriptEncoder::new();
+                    logger.script_message(
+                        Some(tag),
+                        &[b"context", b"username", se.encode(&body.username).borrow()],
+                    );
+                    logger.script_message(
+                        Some(tag),
+                        &[b"context", b"secret", se.encode(&body.secret).borrow()],
+                    );
+                    logger.script_message(
+                        Some(tag),
+                        &[b"context", b"authtype", se.encode(&body.authtype).borrow()],
+                    );
+                    logger.script_message(
+                        Some(tag),
+                        &[b"context", b"type", se.encode(&body.kind).borrow()],
+                    );
+                    logger.script_message(
+                        Some(tag),
+                        &[b"context", b"title", se.encode(&body.title).borrow()],
+                    );
+                    logger.script_message(
+                        Some(tag),
+                        &[
+                            b"context",
+                            b"description",
+                            se.encode(&body.description).borrow(),
+                        ],
+                    );
+                    for loc in body.location {
+                        logger.script_message(
+                            Some(tag),
+                            &[
+                                b"context",
+                                b"location",
+                                se.encode(&loc.protocol).borrow(),
+                                se.encode(&loc.host).borrow(),
+                                se.encode(&loc.port).borrow(),
+                                se.encode(&loc.path).borrow(),
+                            ],
+                        );
+                    }
+                    logger.script_message(
+                        Some(tag),
+                        &[b"context", b"service", se.encode(&body.service).borrow()],
+                    );
+                    logger.script_message(
+                        Some(tag),
+                        &[b"context", b"id", se.encode(&body.id).borrow()],
+                    );
+                }
+                Ok(())
+            }
+            (None, LogFormat::Text) => {
+                logger.message("args:");
+                if let Some(args) = ctx.args {
+                    for arg in args {
+                        logger.message_bytes(&format_bytes!(b"\t{}", arg.as_ref()));
+                    }
+                }
+                let pairs = &[
+                    (&ctx.senv, "senv"),
+                    (&ctx.cenv, "cenv"),
+                    (&ctx.ctxsenv, "ctxsenv"),
+                ];
+                for (data, kind) in pairs {
+                    logger.message(&format!("{}:", kind));
+                    if let Some(args) = data {
+                        for (k, v) in args {
+                            logger.message_bytes(&format_bytes!(
+                                b"\t{}={}",
+                                k.as_ref(),
+                                v.as_ref()
+                            ));
+                        }
+                    }
+                }
+                if let (Some("credential"), Some(body)) = (kind.as_deref(), ctx.body) {
+                    if let Some(username) = &body.username {
+                        logger.message_bytes(&format_bytes!(b"username={}", username.as_ref()));
+                    }
+                    if let Some(secret) = &body.secret {
+                        logger.message_bytes(&format_bytes!(b"secret={}", secret.as_ref()));
+                    }
+                    if let Some(authtype) = &body.authtype {
+                        logger.message_bytes(&format_bytes!(b"authtype={}", authtype.as_bytes(),));
+                    }
+                    logger.message_bytes(&format_bytes!(b"type={}", body.kind.as_bytes()));
+                    logger.message_bytes(&format_bytes!(b"id={}", body.id.as_ref()));
+                    if let Some(title) = body.title {
+                        logger.message_bytes(&format_bytes!(b"title={}", title.as_bytes(),));
+                    }
+                    if let Some(desc) = body.description {
+                        logger.message_bytes(&format_bytes!(b"description={}", desc.as_bytes(),));
+                    }
+                    let mut s = String::with_capacity(128);
+                    for loc in body.location {
+                        if let (Some(protocol), Some(host)) = (&loc.protocol, &loc.host) {
+                            s += &protocol;
+                            s += "://";
+                            s += &host;
+                        }
+                        if let Some(port) = loc.port {
+                            use std::fmt::Write;
+
+                            s += ":";
+                            let _ = write!(s, "{}", port);
+                        }
+                        s += match &loc.path {
+                            Some(path) => path,
+                            None => "/",
+                        };
+                        logger.message(&format!("location={}", s));
+                    }
+                    if let Some(service) = body.service {
+                        logger.message_bytes(&format_bytes!(b"service={}", service.as_bytes()));
+                    }
+                }
+                Ok(())
+            }
+            (Some(pat), LogFormat::CBOR) | (Some(pat), LogFormat::JSON) => {
+                match format_template(ctx, pat.as_bytes()) {
+                    Ok(data) => {
+                        let body = TemplateContextFormatResponse { data };
+                        logger.serialized_message(&body);
+                    }
+                    Err(e) => logger.serialized_error(&e),
+                }
+                Ok(())
+            }
+            (Some(pat), LogFormat::Scriptable) => {
+                let tag = b"_a01";
+                match format_template(ctx, pat.as_bytes()) {
+                    Ok(data) => {
+                        logger.script_message(Some(tag), &[b"context", b"format", &data]);
+                    }
+                    Err(e) => logger.script_error(Some(tag), &e),
+                }
+                Ok(())
+            }
+            (Some(pat), LogFormat::Text) => match format_template(ctx, pat.as_bytes()) {
+                Ok(data) => {
+                    logger.message_bytes(&data);
+                    Ok(())
+                }
+                Err(e) => Err(Error::new_with_cause(ErrorKind::TemplateError, e)),
+            },
+        }
+    })
+}

--- a/lawn/src/template.rs
+++ b/lawn/src/template.rs
@@ -1,5 +1,6 @@
 use crate::encoding::escape;
 use bytes::Bytes;
+use lawn_protocol::protocol;
 use std::collections::BTreeMap;
 use std::fmt;
 use std::sync::Arc;
@@ -168,6 +169,29 @@ pub struct TemplateContext {
     pub cenv: Option<Arc<BTreeMap<Bytes, Bytes>>>,
     pub ctxsenv: Option<Arc<BTreeMap<Bytes, Bytes>>>,
     pub args: Option<Arc<[Bytes]>>,
+}
+
+impl<'a> From<&'a TemplateContext> for protocol::TemplateServerContextBody {
+    fn from(ctx: &'a TemplateContext) -> protocol::TemplateServerContextBody {
+        protocol::TemplateServerContextBody {
+            senv: ctx.senv.as_deref().map(|x| (*x).clone()),
+            cenv: ctx.cenv.as_deref().map(|x| (*x).clone()),
+            ctxsenv: ctx.ctxsenv.as_deref().map(|x| (*x).clone()),
+            args: ctx.args.as_deref().map(|x| x.to_vec()),
+        }
+    }
+}
+
+impl<'a> From<&'a mut TemplateContext> for protocol::TemplateServerContextBody {
+    fn from(ctx: &'a mut TemplateContext) -> protocol::TemplateServerContextBody {
+        protocol::TemplateServerContextBody::from(ctx as &TemplateContext)
+    }
+}
+
+impl From<TemplateContext> for protocol::TemplateServerContextBody {
+    fn from(ctx: TemplateContext) -> protocol::TemplateServerContextBody {
+        protocol::TemplateServerContextBody::from(&ctx)
+    }
 }
 
 #[derive(Default)]

--- a/lawn/src/template.rs
+++ b/lawn/src/template.rs
@@ -88,20 +88,20 @@ impl Template {
     }
 
     fn expand_text_pattern(&self, id: &[u8], context: &TemplateContext) -> Result<Bytes, Error> {
-        if id.starts_with(b"senv:") {
-            Ok(self.expand_env(&id[5..], context.senv.as_deref()))
-        } else if id.starts_with(b"cenv:") {
-            Ok(self.expand_env(&id[5..], context.cenv.as_deref()))
-        } else if id.starts_with(b"ctxsenv:") {
-            Ok(self.expand_env(&id[8..], context.ctxsenv.as_deref()))
-        } else if id.starts_with(b"senv?:") {
-            Ok(self.has_entry(&id[6..], context.senv.as_deref()))
-        } else if id.starts_with(b"cenv?:") {
-            Ok(self.has_entry(&id[6..], context.cenv.as_deref()))
-        } else if id.starts_with(b"ctxsenv?:") {
-            Ok(self.has_entry(&id[9..], context.ctxsenv.as_deref()))
-        } else if id.starts_with(b"sq:") {
-            Ok(self.single_quote(&self.expand_text_pattern(&id[3..], context)?))
+        if let Some(val) = id.strip_prefix(b"senv:") {
+            Ok(self.expand_env(val, context.senv.as_deref()))
+        } else if let Some(val) = id.strip_prefix(b"cenv:") {
+            Ok(self.expand_env(&val, context.cenv.as_deref()))
+        } else if let Some(val) = id.strip_prefix(b"ctxsenv:") {
+            Ok(self.expand_env(&val, context.ctxsenv.as_deref()))
+        } else if let Some(val) = id.strip_prefix(b"senv?:") {
+            Ok(self.has_entry(&val, context.senv.as_deref()))
+        } else if let Some(val) = id.strip_prefix(b"cenv?:") {
+            Ok(self.has_entry(&val, context.cenv.as_deref()))
+        } else if let Some(val) = id.strip_prefix(b"ctxsenv?:") {
+            Ok(self.has_entry(&val, context.ctxsenv.as_deref()))
+        } else if let Some(val) = id.strip_prefix(b"sq:") {
+            Ok(self.single_quote(&self.expand_text_pattern(&val, context)?))
         } else {
             Err(Error::UnknownPattern(id.to_vec().into()))
         }

--- a/lawn/src/template.rs
+++ b/lawn/src/template.rs
@@ -169,6 +169,8 @@ pub struct TemplateContext {
     pub cenv: Option<Arc<BTreeMap<Bytes, Bytes>>>,
     pub ctxsenv: Option<Arc<BTreeMap<Bytes, Bytes>>>,
     pub args: Option<Arc<[Bytes]>>,
+    pub kind: Option<String>,
+    pub extra: Option<serde_cbor::Value>,
 }
 
 impl<'a> From<&'a TemplateContext> for protocol::TemplateServerContextBody {
@@ -191,6 +193,56 @@ impl<'a> From<&'a mut TemplateContext> for protocol::TemplateServerContextBody {
 impl From<TemplateContext> for protocol::TemplateServerContextBody {
     fn from(ctx: TemplateContext) -> protocol::TemplateServerContextBody {
         protocol::TemplateServerContextBody::from(&ctx)
+    }
+}
+
+impl<'a, T> From<&'a TemplateContext> for protocol::TemplateServerContextBodyWithBody<T> {
+    fn from(ctx: &'a TemplateContext) -> protocol::TemplateServerContextBodyWithBody<T> {
+        protocol::TemplateServerContextBodyWithBody {
+            senv: ctx.senv.as_deref().map(|x| (*x).clone()),
+            cenv: ctx.cenv.as_deref().map(|x| (*x).clone()),
+            ctxsenv: ctx.ctxsenv.as_deref().map(|x| (*x).clone()),
+            args: ctx.args.as_deref().map(|x| x.to_vec()),
+            body: None,
+        }
+    }
+}
+
+impl<'a, T> From<&'a mut TemplateContext> for protocol::TemplateServerContextBodyWithBody<T> {
+    fn from(ctx: &'a mut TemplateContext) -> protocol::TemplateServerContextBodyWithBody<T> {
+        protocol::TemplateServerContextBodyWithBody::from(ctx as &TemplateContext)
+    }
+}
+
+impl<T> From<TemplateContext> for protocol::TemplateServerContextBodyWithBody<T> {
+    fn from(ctx: TemplateContext) -> protocol::TemplateServerContextBodyWithBody<T> {
+        protocol::TemplateServerContextBodyWithBody::from(&ctx)
+    }
+}
+
+impl From<protocol::TemplateServerContextBody> for TemplateContext {
+    fn from(ctx: protocol::TemplateServerContextBody) -> TemplateContext {
+        TemplateContext {
+            senv: ctx.senv.map(Arc::new),
+            cenv: ctx.cenv.map(Arc::new),
+            ctxsenv: ctx.ctxsenv.map(Arc::new),
+            args: ctx.args.map(|v| v.into_boxed_slice().into()),
+            kind: None,
+            extra: None,
+        }
+    }
+}
+
+impl<T> From<protocol::TemplateServerContextBodyWithBody<T>> for TemplateContext {
+    fn from(ctx: protocol::TemplateServerContextBodyWithBody<T>) -> TemplateContext {
+        TemplateContext {
+            senv: ctx.senv.map(Arc::new),
+            cenv: ctx.cenv.map(Arc::new),
+            ctxsenv: ctx.ctxsenv.map(Arc::new),
+            args: ctx.args.map(|v| v.into_boxed_slice().into()),
+            kind: None,
+            extra: None,
+        }
     }
 }
 

--- a/lawn/src/template.rs
+++ b/lawn/src/template.rs
@@ -1,6 +1,8 @@
 use crate::encoding::escape;
 use bytes::Bytes;
+use lawn_constants::error::ExtendedError;
 use lawn_protocol::protocol;
+use std::borrow::Cow;
 use std::collections::BTreeMap;
 use std::fmt;
 use std::sync::Arc;
@@ -41,6 +43,20 @@ impl fmt::Display for Error {
 }
 
 impl std::error::Error for Error {}
+
+impl ExtendedError for Error {
+    fn error_types(&self) -> Cow<'static, [Cow<'static, str>]> {
+        Cow::Borrowed(&[Cow::Borrowed("template")])
+    }
+
+    fn error_tag(&self) -> Cow<'static, str> {
+        match self {
+            Self::InvalidCharacter(..) => Cow::Borrowed("invalid-character"),
+            Self::InvalidRadixCharacter => Cow::Borrowed("invalid-radix-character"),
+            Self::UnknownPattern(..) => Cow::Borrowed("unknown-pattern"),
+        }
+    }
+}
 
 impl Template {
     pub fn new(s: &[u8]) -> Template {

--- a/lawn/src/tests.rs
+++ b/lawn/src/tests.rs
@@ -16,7 +16,7 @@ use std::convert::TryFrom;
 use std::ffi::{OsStr, OsString};
 use std::fs;
 use std::io;
-use std::io::{Cursor, Read, Write};
+use std::io::{Cursor, Write};
 use std::os::unix::ffi::{OsStrExt, OsStringExt};
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
@@ -162,6 +162,10 @@ v0:
         let mut path = self.dir.path().to_owned();
         path.push("runtime/lawn/server-0.sock");
         client.connect(path, false).await.unwrap()
+    }
+
+    pub fn tempdir(&self) -> &Path {
+        self.dir.path()
     }
 }
 
@@ -903,6 +907,230 @@ fn can_round_trip_data_through_memory_credential_helper() {
                 .await
                 .unwrap();
             assert!(cred.is_none(), "missing credential is missing");
+        });
+    }
+}
+
+#[test]
+fn can_insert_entries_with_lawn_query() {
+    use crate::credential::{Credential, CredentialClient, CredentialHandle, Location};
+    use bytes::BytesMut;
+    use tokio::io::AsyncReadExt;
+
+    let authers: [Arc<dyn Auther + Send + Sync>; 2] =
+        [Arc::new(PlainAuth), Arc::new(KeyboardInteractiveAuth)];
+
+    let config = format!(
+        "{}\n{}",
+        TestInstance::default_config_file(),
+        r#"
+    credential:
+        if: true
+        control: |
+          !f() {
+            if [ "$0" = "create-location" ]
+            then
+                username=$(lawn -vvvv --format=script query context --list | tee -a %(sq:senv:LAWN_TEST_DATA_DIR)/context | grep "context username" |
+                  sed -e "s/^.*context username @//")
+                if [ "$username" = "username" ]
+                then
+                    echo "/memory/vault1/"
+                else
+                    echo "/memory/vault2/foo/bar/"
+                fi
+            else
+                false
+            fi
+          }; f
+        backends:
+            - name: memory
+              type: memory
+              if: true
+              options:
+                  token: abc123
+"#
+    );
+    let mut capabilities = Capability::implemented();
+    capabilities.insert(Capability::StoreCredential);
+
+    for auther in &authers {
+        let mut cb = ConfigBuilder::new();
+        cb.capabilities(capabilities.clone());
+
+        let ti = Arc::new(TestInstance::new(Some(cb), Some(&config)));
+        let auther = auther.clone();
+        with_server(ti.clone(), async move {
+            // Basic setup.
+            let c = ti.connection().await;
+            c.ping().await.unwrap();
+            let resp = c.negotiate_default_version().await.unwrap();
+            assert_eq!(resp.version, &[0], "version is correct");
+            assert_eq!(
+                resp.user_agent.unwrap(),
+                config::VERSION,
+                "user-agent is correct"
+            );
+            c.auth_external().await.unwrap();
+
+            let creds = CredentialClient::new(c).await.unwrap();
+            let mut stores = creds.list_stores().await.unwrap();
+            assert_eq!(stores.len(), 1, "one store");
+            assert_eq!(stores[0].path().await, "/memory/", "correct path");
+
+            let entries = creds.list_entries().await.unwrap().collect::<Vec<_>>();
+            assert_eq!(entries.len(), 1, "one store as entry");
+            assert_eq!(entries[0].path, "/memory/", "correct path for entry");
+            assert_eq!(
+                entries[0].needs_authentication,
+                Some(true),
+                "needs authentication"
+            );
+            assert_eq!(
+                entries[0].authentication_methods,
+                Some(vec![
+                    Bytes::from(b"PLAIN" as &[u8]),
+                    Bytes::from(b"keyboard-interactive" as &[u8])
+                ]),
+                "needs authentication with expected methods"
+            );
+
+            let e = stores[0].list_vaults().await.unwrap_err();
+            assert_eq!(ce_to_pe(e).code, ResponseCode::NeedsAuthentication);
+            auther.auth(&mut stores[0]).await;
+
+            let vaults = stores[0].list_vaults().await.unwrap();
+            assert!(vaults.is_empty(), "no vaults");
+            let vault1 = stores[0].create_vault(b"vault1").await.unwrap();
+            let vault2 = stores[0].create_vault(b"vault2").await.unwrap();
+            let vaults = stores[0].list_vaults().await.unwrap();
+            assert_eq!(vaults.len(), 2, "two vaults");
+            assert_eq!(
+                vaults[0].path().await,
+                b"/memory/vault1/" as &[u8],
+                "correct vault path"
+            );
+            assert_eq!(
+                vaults[0].path().await,
+                vault1.path().await,
+                "consistent vault path"
+            );
+            assert_eq!(
+                vaults[1].path().await,
+                b"/memory/vault2/" as &[u8],
+                "correct vault path"
+            );
+            assert_eq!(
+                vaults[1].path().await,
+                vault2.path().await,
+                "consistent vault path"
+            );
+
+            let mut cred1 = Credential {
+                username: Some(Bytes::from(b"username" as &[u8])),
+                secret: Bytes::from(b"secret" as &[u8]),
+                authtype: Some("PLAIN".into()),
+                kind: "api".into(),
+                title: Some("title".into()),
+                description: Some("description".into()),
+                service: Some("git".into()),
+                extra: BTreeMap::new(),
+                id: Bytes::new(),
+                location: vec![Location {
+                    protocol: Some("https".into()),
+                    host: Some("example.com".into()),
+                    port: Some(443),
+                    path: Some("/git/foo/bar".into()),
+                }],
+            };
+            cred1.id = cred1.generate_id();
+            assert_eq!(cred1.id.as_ref(), b"20aafdb3831287f75a74dd7c2843e7cbd87df92b91944f4311a940eabfa633651107f8bc24bfd563cc4c8de6f80b0e3a9e67af0e76f85044283531974a6be138", "credential has expected ID");
+            let cred1_path = Bytes::from(format_bytes!(b"/memory/vault1/{}", cred1.id.as_ref()));
+            assert_eq!(cred1_path.as_ref(), b"/memory/vault1/20aafdb3831287f75a74dd7c2843e7cbd87df92b91944f4311a940eabfa633651107f8bc24bfd563cc4c8de6f80b0e3a9e67af0e76f85044283531974a6be138", "credential path is as expected");
+
+            let mut cred2 = Credential {
+                username: Some(Bytes::from(b"someone-else" as &[u8])),
+                secret: Bytes::from(b"secret" as &[u8]),
+                authtype: Some("PLAIN".into()),
+                kind: "api".into(),
+                title: Some("title".into()),
+                description: Some("description".into()),
+                service: Some("git".into()),
+                extra: BTreeMap::new(),
+                id: Bytes::new(),
+                location: vec![Location {
+                    protocol: Some("https".into()),
+                    host: Some("example.com".into()),
+                    port: Some(443),
+                    path: Some("/git/foo/baz".into()),
+                }],
+            };
+            cred2.id = cred2.generate_id();
+            let cred2_path = Bytes::from(format_bytes!(
+                b"/memory/vault2/foo/bar/{}",
+                cred2.id.as_ref()
+            ));
+            assert_eq!(cred2_path.as_ref(), b"/memory/vault2/foo/bar/857ff0c8c6cad14f7e4e70b3ed3a69b673a8ed297c963fce899b7d445266737a35cb67485263ceac977daed3f191a69df03a9a85ac258b33a8bcc3e76692d1ea", "credential path is as expected");
+
+            creds.create_entry(&cred1).await.unwrap();
+            let items = vault1.list_entries().await.unwrap().collect::<Vec<_>>();
+            assert_eq!(items.len(), 1, "one vault entry");
+            assert_eq!(items[0].path, cred1_path, "vault entry has expected path");
+
+            let expected = vault1.get_entry(&cred1.id).await.unwrap().unwrap();
+            assert_eq!(expected, cred1, "cred1 is round-tripped correctly");
+
+            let foodir = vault2.create_directory(b"foo").await.unwrap();
+            let bardir = foodir.create_directory(b"bar").await.unwrap();
+            creds.create_entry(&cred2).await.unwrap();
+            let items = bardir.list_entries().await.unwrap().collect::<Vec<_>>();
+            assert_eq!(items.len(), 1, "one vault entry in directory");
+            assert_eq!(
+                items[0].path, cred2_path,
+                "vault entry in directory has expected path"
+            );
+
+            let mut data_file = ti.tempdir().to_owned();
+            data_file.push("data");
+            data_file.push("context");
+            let mut buf = BytesMut::with_capacity(65536);
+            let mut fp = tokio::fs::File::open(data_file).await.unwrap();
+            fp.read_buf(&mut buf).await.unwrap();
+
+            // Filter out the LAWN environment variable because it contains a socket in a tempdir
+            // and it will vary.
+            let actual = buf
+                .split_inclusive(|b| *b == b'\n')
+                .filter(|ln| !ln.starts_with(b"_a01 ok context ctxsenv"))
+                .collect::<Vec<_>>();
+            let actual = Bytes::from(actual.join(&[][..]));
+            const FIXED: &[u8] = b"_a01 ok context";
+            let config = ti.config();
+            let senv = config.env_vars();
+            let prefix = format_bytes!(b"{} args create-location\n{} senv HOME {}\n{} senv LAWN_TEST_DATA_DIR {}\n{} senv PATH {}\n{} senv XDG_RUNTIME_DIR {}\n", FIXED, FIXED, senv.get(b"HOME".as_slice()).unwrap().as_ref(), FIXED, senv.get(b"LAWN_TEST_DATA_DIR".as_slice()).unwrap().as_ref(), FIXED, *senv.get(b"PATH".as_slice()).unwrap().as_ref(), FIXED, *senv.get(b"XDG_RUNTIME_DIR".as_slice()).unwrap().as_ref());
+            let mut expected = prefix.clone();
+            let _ = write!(expected, "_a01 ok context template-type credential
+_a01 ok context username @username
+_a01 ok context secret @secret
+_a01 ok context authtype @PLAIN
+_a01 ok context type api
+_a01 ok context title @title
+_a01 ok context description @description
+_a01 ok context location @https @example.com @443 @/git/foo/bar
+_a01 ok context service @git
+_a01 ok context id 20aafdb3831287f75a74dd7c2843e7cbd87df92b91944f4311a940eabfa633651107f8bc24bfd563cc4c8de6f80b0e3a9e67af0e76f85044283531974a6be138\n");
+            expected.extend(prefix);
+            let _ = write!(expected, "_a01 ok context template-type credential
+_a01 ok context username @someone-else
+_a01 ok context secret @secret
+_a01 ok context authtype @PLAIN
+_a01 ok context type api
+_a01 ok context title @title
+_a01 ok context description @description
+_a01 ok context location @https @example.com @443 @/git/foo/baz
+_a01 ok context service @git
+_a01 ok context id 857ff0c8c6cad14f7e4e70b3ed3a69b673a8ed297c963fce899b7d445266737a35cb67485263ceac977daed3f191a69df03a9a85ac258b33a8bcc3e76692d1ea\n");
+            let expected = Bytes::from(expected);
+            assert_eq!(actual, expected);
         });
     }
 }

--- a/lawn/src/tests.rs
+++ b/lawn/src/tests.rs
@@ -1029,7 +1029,11 @@ fn can_read_template_contexts() {
         let g = cfg.template_context(Some(cenv.clone()), Some(args.clone()));
         let id = g.context_id();
 
-        let ctx = c.read_template_context(id.clone()).await.unwrap().unwrap();
+        let (_kind, ctx) = c
+            .read_template_context::<serde_cbor::Value>(id.clone())
+            .await
+            .unwrap()
+            .unwrap();
         assert!(ctx.senv.is_some(), "server environment exists");
         assert_eq!(
             ctx.cenv.unwrap(),
@@ -1041,7 +1045,10 @@ fn can_read_template_contexts() {
         std::mem::drop(g);
 
         assert!(
-            c.read_template_context(id.clone()).await.unwrap().is_none(),
+            c.read_template_context::<serde_cbor::Value>(id.clone())
+                .await
+                .unwrap()
+                .is_none(),
             "template context is absent"
         );
     });

--- a/lawn/src/tests.rs
+++ b/lawn/src/tests.rs
@@ -53,11 +53,14 @@ impl FakeEnvironment {
             "XDG_RUNTIME_DIR" => Some(Cow::Borrowed(b"runtime" as &[u8])),
             "LAWN_TEST_DATA_DIR" => Some(Cow::Borrowed(b"data" as &[u8])),
             "PATH" => {
+                let cwd = cwd.as_os_str().as_bytes();
                 return Some(OsString::from_vec(format_bytes!(
-                    b"{}/../spec/fixtures/bin:{}",
-                    cwd.as_os_str().as_bytes(),
+                    b"{}/../spec/fixtures/bin:{}/../target/release:{}/../target/debug:{}",
+                    cwd,
+                    cwd,
+                    cwd,
                     path.as_bytes(),
-                )))
+                )));
             }
             _ => None,
         }?;

--- a/lawn/src/tests.rs
+++ b/lawn/src/tests.rs
@@ -92,11 +92,12 @@ pub struct TestInstance {
 impl TestInstance {
     pub fn new(builder: Option<ConfigBuilder>, config: Option<&str>) -> Self {
         let dir = tempfile::tempdir().unwrap();
-        let mut server = dir.path().to_owned();
-        server.push("server");
-        fs::create_dir(&server).unwrap();
+        let mut config_dir = dir.path().to_owned();
+        config_dir.push("home/.config/lawn");
+        fs::create_dir_all(&config_dir).unwrap();
         let paths = &[
             "home/.local/run/lawn",
+            "home/.config/lawn",
             "data",
             "path",
             "run/user",
@@ -109,7 +110,7 @@ impl TestInstance {
             to_create.push(p);
             fs::create_dir_all(&to_create).unwrap();
         }
-        let config_file = Self::write_config_file(&server, config);
+        let config_file = Self::write_config_file(&config_dir, config);
         let env = FakeEnvironment::new(dir.path());
         let iterenv = env.clone();
         let mut builder = builder.unwrap_or_else(|| ConfigBuilder::new());

--- a/spec/credential_spec.rb
+++ b/spec/credential_spec.rb
@@ -1,0 +1,76 @@
+require_relative 'spec_helper'
+
+describe "credentials" do
+  def git_credential_approve(env, input)
+    data = env.run([
+      "git", "-c", "credential.helper=", "-c", "credential.helper=!lawn credential git", "credential", "approve"
+    ], input: input, output: true)
+    out, err = env.output_from_process(data)
+    expect(out).to be_empty
+    expect(err).to be_empty
+  end
+
+  def git_credential_reject(env, input)
+    data = env.run([
+      "git", "-c", "credential.helper=", "-c", "credential.helper=!lawn credential git", "credential", "reject"
+    ], input: input, output: true)
+    out, err = env.output_from_process(data)
+    expect(out).to be_empty
+    expect(err).to be_empty
+  end
+
+  def git_credential_fill(env, input)
+    input = "url=https://git.example.com\n"
+    data = env.run([
+      "git", "-c", "credential.helper=", "-c", "credential.helper=!lawn credential git", "credential", "fill"
+    ], input: input, output: true, env: {"GIT_TERMINAL_PROMPT" => "0"})
+    env.output_from_process(data)
+  end
+
+  def create_vault(env, vault)
+    input = "a01 mkdir #{vault}\n"
+    data = env.run(%w[lawn credential script], input: input, output: true)
+    out, err = env.output_from_process(data)
+    expect(out).to eq "a01 ok mkdir #{vault}\n"
+    expect(err).to be_empty
+  end
+
+  def cred_helper_test(env, reject_string)
+    create_vault(env, "/memory/vault/")
+    git_credential_approve(env, "url=https://git.example.com\nusername=foo\npassword=bar\n")
+
+    out, err = git_credential_fill(env, "url=https://git.example.com\n")
+    expect(err).to be_empty
+    entries = out.chomp.split("\n").map { |ln| ln.split("=", 2) }.to_h
+    expected = {"protocol" => "https", "host" => "git.example.com", "username" => "foo", "password" => "bar"}
+    expect(entries).to eq expected
+
+    git_credential_reject(env, reject_string)
+
+    out, err = git_credential_fill(env, "url=https://git.example.com\n")
+    expect(out).to be_empty
+    # Git will try to prompt since the creds don't exist and complain.
+    expect(err).to_not be_empty
+  end
+
+  it "should save and remove credentials from a Git credential helper using full credentials" do
+    env = TestEnvironment.new
+    env.start_server
+
+    cred_helper_test(env, "url=https://git.example.com\nusername=foo\npassword=bar\n")
+  end
+
+  it "should save and remove credentials from a Git credential helper using just a username and URL" do
+    env = TestEnvironment.new
+    env.start_server
+
+    cred_helper_test(env, "url=https://git.example.com\nusername=foo\n")
+  end
+
+  it "should save and remove credentials from a Git credential helper using just a URL" do
+    env = TestEnvironment.new
+    env.start_server
+
+    cred_helper_test(env, "url=https://git.example.com\n")
+  end
+end

--- a/spec/fixtures/config.yaml
+++ b/spec/fixtures/config.yaml
@@ -25,3 +25,16 @@ v0:
     remote:
       if: true
       location: '!printf "%s" "$LAWN_SERVER_MOUNT"'
+  credential:
+    if: true
+    control: |
+      !f() {
+        case $0 in
+          create-location)
+            echo /memory/vault/;;
+        esac
+      }; f
+    backends:
+      - name: memory
+        type: memory
+        if: true

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -65,6 +65,10 @@ class TestEnvironment
       "LAWN_SERVER_MOUNT" => File.join(dir, "mount", "server"),
       "LAWN_BASE_DIR" => dir,
     }
+    extra_env = options.delete(:env)
+    if extra_env
+      env.merge!(extra_env)
+    end
     data = {}
     inp = options.delete(:input)
     outp = options.delete(:output)


### PR DESCRIPTION
Currently, our Git credential helper always attempts to insert credentials into the first vault.  This is suboptimal because it doesn't allow users to choose where their credentials are placed.

This series introduces a control configuration option that allows the user to specify this, and a new Lawn subcommand, `lawn query context`, to query aspects of the context and credential being used so as to pick the correct location.  Note that the credential is only exposed over the protocol if the caller knows a random 32-byte (256-bit) context ID, which is only passed to the command in the control option via the environment.  Thus, this feature is unlikely to accidentally expose credentials.