### PR TITLE
Add docs and minor protocol fixes for server context

### DIFF
--- a/doc/protocol.adoc
+++ b/doc/protocol.adoc
@@ -277,7 +277,7 @@ The following capabilities are known:
 
 | `auth`      | `EXTERNAL`             | external authentication
 | `auth`      | `PLAIN`                | SASL PLAIN authentication
-| `auth`      | `keyboard-interactive` | SASL PLAIN authentication
+| `auth`      | `keyboard-interactive` | keyboard-interactive authentication
 | `auth`      | any uppercase string   | Any standardized SASL authentication mechanism
 | `auth`      | any lowercase string   | Reserved for future Lawn-defined authentication mechanisms
 | `auth`      | any extension string   | Reserved for custom extensions

--- a/doc/protocol.adoc
+++ b/doc/protocol.adoc
@@ -213,6 +213,11 @@ An implementation supporting any two-part capability with the first part of `sto
 
 Such an implementation must also support the Unlisted response.
 
+An implementation supporting any two-part capability with the first part of `context` must support the following requests:
+
+* ReadServerContext
+* WriteServerContext
+
 === Major Concepts
 
 ==== Channels
@@ -239,6 +244,11 @@ Stores can be used for any sort of structured data, including credentials.
 
 Objects in stores can be specified either with an absolute path (called a _store selector path_) or with an ID (called a _store selector ID_).
 The latter is a 32-bit integer returned by some store operations and is not the same as the ID which is returned in the path.
+
+==== Contexts
+
+A context provides some information about the server state and may optionally allow it to be modified.
+This information may be information about a command being run or other, more global server information.
 
 === Requests
 
@@ -289,6 +299,9 @@ The following capabilities are known:
 
 | `store`     | `credential`         | credential stores
 | `store`     | any extension string | Reserved for custom extensions
+
+| `context`   | `template`           | template contexts
+| `context`   | any extension string | Reserved for custom extensions
 
 | `extension` | `allocate`           | dynamic message code extensions
 
@@ -890,6 +903,7 @@ The `kind` value is always `credential` or `directory`.
 The `path` component in an OpenStore request is not used and should be null.
 The `meta` values are not used unless an extension string is specified as a key and should otherwise be null.
 
+[[credential-body]]
 A credential body looks like this:
 
 ----
@@ -1311,6 +1325,90 @@ The body is a normal type-specific body or null if there is no such body.
 The meaning of the values are otherwise the same as for the CreateStoreElement request.
 
 This request is paginated and requires authentication.
+
+==== ReadServerContext
+
+The read server context request (`0x00040000`) requests that a server context be read and its data returned.
+
+A request looks like this:
+
+----
+{
+  kind: String,
+  id: Option<Bytes>,
+  meta: Option<Map<Bytes, Value>>,
+}
+----
+
+For template contexts, `kind` is `template`, `id` is the randomly-generated ID for the template, and `meta` contains the `template-type` key mapped to the template type.
+
+On success, the response looks like this:
+
+----
+{
+  id: Option<Bytes>,
+  meta: Option<Map<Bytes, Value>>,
+  body: Option<type-specific>,
+}
+----
+
+This request requires authentication.
+
+===== Template Contexts
+
+Template contexts provide information about a shell command invoked from the server.
+They can also contain additional data, such as credential information, for credential commands.
+
+A template context body looks like this:
+
+----
+{
+  senv: Option<Map<Bytes, Bytes>>,
+  cenv: Option<Map<Bytes, Bytes>>,
+  ctxsenv: Option<Map<Bytes, Bytes>>,
+  args: Option<Vec<Bytes>>,
+  body: Option<type-specific>,
+}
+----
+
+`senv` is the server Unix environment which is shared across the server and is usually set on server startup.
+`cenv` is the client Unix environment, if provided, which contains the environment of the Lawn client making this request.
+`ctxsenv` is a context-specific server Unix environment, which may contain the `LAWN` environment variable and any other environment variables which must be passed in this context (such as environment variables required for authentication to a credential backend).
+`args` is the command-line arguments passed to the command.
+`body` may be missing if it is null.
+
+If the `template-type` value in the `meta` variable is `credential`, then `body` is a <<credential-body,credential body>>.
+
+==== WriteServerContext
+
+The write server context request (`0x00040001`) requests that a server context be written.
+
+A request looks like this:
+
+----
+{
+  kind: String,
+  id: Option<Bytes>,
+  meta: Option<Map<Bytes, Value>>,
+  body: Option<type-specific>,
+}
+----
+
+The `body` field may be omitted if it is not needed.
+
+On success, the response looks like this:
+
+----
+{
+  id: Option<Bytes>,
+  meta: Option<Map<Bytes, Value>>,
+  body: Option<type-specific>,
+}
+----
+
+The `body` field may be omitted if it is not needed or does not differ from the request.
+
+This request requires authentication.
 
 === Responses
 

--- a/lawn-protocol/src/protocol/mod.rs
+++ b/lawn-protocol/src/protocol/mod.rs
@@ -1080,10 +1080,18 @@ pub struct WriteServerContextRequest {
 
 #[derive(Serialize, Deserialize, Eq, PartialEq, Ord, PartialOrd, Clone)]
 #[serde(rename_all = "kebab-case")]
-pub struct WriteServerContextResponseWithBody<T> {
+pub struct WriteServerContextRequestWithBody<T> {
+    pub kind: String,
     pub id: Option<Bytes>,
     pub meta: Option<BTreeMap<Bytes, Value>>,
     pub body: Option<T>,
+}
+
+#[derive(Serialize, Deserialize, Eq, PartialEq, Ord, PartialOrd, Clone)]
+#[serde(rename_all = "kebab-case")]
+pub struct WriteServerContextResponse {
+    pub id: Option<Bytes>,
+    pub meta: Option<BTreeMap<Bytes, Value>>,
 }
 
 #[derive(Serialize, Deserialize, Eq, PartialEq, Ord, PartialOrd, Clone)]


### PR DESCRIPTION
Fix a minor nit in the protocol for writing server contexts and include protocol documentation for this.  In addition, fix a minor typo in the protocol documentation.