### PR TITLE
.github/workflows: use nested virtualization on Linux for BSDs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
     - run: make ci-stable
   build-freebsd:
     name: FreeBSD
-    runs-on: macos-12
+    runs-on: ubuntu-latest
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     steps:
     - uses: actions/checkout@v3
@@ -60,15 +60,31 @@ jobs:
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: 3.1
+    - name: Enable KVM group perms
+      run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+    - run: sudo apt-get -y install vagrant vagrant-libvirt libvirt-daemon-system
+    - run: sudo service libvirtd start
+    - run: sudo chmod 666 /var/run/libvirt/libvirt-sock
     - run: make ci-freebsd
   build-netbsd:
     name: NetBSD
-    runs-on: macos-12
+    runs-on: ubuntu-latest
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     steps:
     - uses: actions/checkout@v3
       with:
         fetch-depth: 0
+    - name: Enable KVM group perms
+      run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+    - run: sudo apt-get -y install vagrant vagrant-libvirt libvirt-daemon-system
+    - run: sudo service libvirtd start
+    - run: sudo chmod 666 /var/run/libvirt/libvirt-sock
     - run: make ci-netbsd
   build-mac:
     name: macOS

--- a/lawn-fs/src/backend/libc.rs
+++ b/lawn-fs/src/backend/libc.rs
@@ -482,14 +482,14 @@ impl LibcBackend {
         dest: PathBuf,
         st: &'_ mut WalkState<'_>,
     ) -> Result<QID> {
-        st.full_path = dest.clone();
+        st.full_path.clone_from(&dest);
         // If this is the last component, we don't need to try to open it since we're not walking a
         // directory.
         if st.last {
             let metadata = fs::symlink_metadata(&dest)?;
             let ft = QIDKind::from_metadata(&metadata);
             st.kind = ft;
-            st.next_full_path = st.full_path.clone();
+            st.next_full_path.clone_from(&st.full_path);
             st.file = None;
             st.dev = metadata.dev();
             st.ino = metadata.ino();
@@ -513,7 +513,7 @@ impl LibcBackend {
                     QID::default()
                 };
                 st.kind = qid.kind();
-                st.next_full_path = st.full_path.clone();
+                st.next_full_path.clone_from(&st.full_path);
                 st.file = Some(Arc::new(fd));
                 st.dev = qid.dev();
                 st.ino = qid.ino();
@@ -561,7 +561,7 @@ impl LibcBackend {
                     )?),
                 };
                 st.kind = QIDKind::Directory;
-                st.next_full_path = st.full_path.clone();
+                st.next_full_path.clone_from(&st.full_path);
                 st.file = Some(file);
                 st.dev = qid.dev();
                 st.ino = qid.ino();
@@ -1107,8 +1107,8 @@ impl Backend for LibcBackend {
                 (_, Err(_)) => break,
             }
             if !last {
-                st.full_path = st.next_full_path.clone();
-                st.dir = st.file.clone();
+                st.full_path.clone_from(&st.next_full_path);
+                st.dir.clone_from(&st.file);
                 st.file = None;
             }
         }

--- a/lawn/src/credential.rs
+++ b/lawn/src/credential.rs
@@ -943,8 +943,6 @@ pub trait CredentialHandle {
     async fn path(&self) -> Bytes;
 }
 
-pub trait CredentialSet {}
-
 // This value is serialized in some of the backends.  If you change it incompatibly, be sure to
 // separate that usage out into a separate struct.
 #[derive(Serialize, Deserialize, Default, Clone, Eq, PartialEq, Ord, PartialOrd, Debug)]

--- a/lawn/src/credential/protocol/git.rs
+++ b/lawn/src/credential/protocol/git.rs
@@ -317,9 +317,9 @@ impl GitProtocolHandler {
             cred.location = vec![loc];
         }
         if cred.service.is_none() {
-            cred.service = self.service.clone();
+            cred.service.clone_from(&self.service);
         }
-        cred.kind = self.kind.clone();
+        cred.kind.clone_from(&self.kind);
         cred.title = (*self.titler)(&cred);
         cred.id = id.unwrap_or_else(|| cred.generate_id());
         if has_secret || !need_secret {

--- a/lawn/src/serializer/script.rs
+++ b/lawn/src/serializer/script.rs
@@ -61,17 +61,11 @@ impl ScriptEncoder {
         Self {}
     }
 
-    pub fn encode<'a, T: Encodable>(&self, val: &'a T) -> Cow<'a, [u8]>
-    where
-        T: ?Sized,
-    {
+    pub fn encode<'a, T: Encodable + ?Sized>(&self, val: &'a T) -> Cow<'a, [u8]> {
         val.encode()
     }
 
-    pub fn encode_to_bytes<T: Encodable>(&self, val: &T) -> Bytes
-    where
-        T: ?Sized,
-    {
+    pub fn encode_to_bytes<T: Encodable + ?Sized>(&self, val: &T) -> Bytes {
         val.encode_to_bytes()
     }
 

--- a/lawn/src/store.rs
+++ b/lawn/src/store.rs
@@ -101,6 +101,7 @@ impl StoreAuthenticationMetadata {
     }
 }
 
+#[allow(dead_code)]
 pub trait StoreElementEntry {
     fn store_id(&self) -> StoreID;
     fn path(&self) -> Bytes;
@@ -173,6 +174,7 @@ impl StoreElementEntry for PlainStoreElementEntry {
 type BoxedStoreElementEntryIterator =
     Box<dyn Iterator<Item = Arc<dyn StoreElementEntry + Send + Sync>> + Send + Sync>;
 
+#[allow(dead_code)]
 pub trait StoreElement {
     fn store_id(&self) -> StoreID;
     fn id(&self) -> StoreSelectorID;
@@ -224,6 +226,7 @@ pub trait StoreElement {
     >;
 }
 
+#[allow(dead_code)]
 pub trait Store {
     fn id(&self) -> StoreID;
     fn acquire(

--- a/lawn/src/store/credential.rs
+++ b/lawn/src/store/credential.rs
@@ -22,6 +22,7 @@ pub mod git;
 pub mod helpers;
 pub mod memory;
 
+#[allow(dead_code)]
 pub trait CredentialBackend {
     fn name(&self) -> &[u8];
     fn vaults(&self) -> Result<Cow<'_, [Bytes]>, CredentialParserError>;
@@ -53,8 +54,8 @@ pub trait CredentialBackend {
     fn authentication_metadata(&self) -> Option<StoreAuthenticationMetadata>;
 }
 
+#[allow(dead_code)]
 pub trait CredentialBackendHandle {
-    fn config(&self) -> Arc<Config>;
     fn store_id(&self) -> StoreID;
     fn id(&self) -> StoreSelectorID;
     fn to_store_element_entry(self: Arc<Self>) -> Arc<dyn StoreElementEntry + Send + Sync>;
@@ -190,10 +191,6 @@ impl StoreElement for TopLevelCredentialBackendHandle {
 }
 
 impl CredentialBackendHandle for TopLevelCredentialBackendHandle {
-    fn config(&self) -> Arc<Config> {
-        self.config.clone()
-    }
-
     fn store_id(&self) -> StoreID {
         self.store_id
     }
@@ -459,6 +456,7 @@ impl<T: CredentialBackendHandle> StoreElement for CredentialBackendStoreElement<
     }
 }
 
+#[allow(dead_code)]
 pub trait CredentialVault: StoreElement {
     fn name(&self) -> &[u8];
     fn search(

--- a/lawn/src/store/credential/helpers.rs
+++ b/lawn/src/store/credential/helpers.rs
@@ -224,10 +224,6 @@ impl<
         U: CommandCredentialBackend<Backend = T> + Send + Sync + 'static,
     > CredentialBackendHandle for CommandCredentialBackendHandle<T, U>
 {
-    fn config(&self) -> Arc<Config> {
-        self.parent.clone().config()
-    }
-
     fn store_id(&self) -> StoreID {
         self.store_id
     }


### PR DESCRIPTION
We'd like to be able to support nested virtualization on Linux rather than macOS.  Linux VMs are less restricted in terms of capacity; they're faster than macOS; and they're on x86-64, like our existing images, which is helpful since the x86-64 images are the best maintained on Vagrant.  Be sure to install Vagrant since it's not available by default on Ubuntu systems, and to use the libvirt backend since we're using `/dev/kvm`.