### PR TITLE
workflows/ci: allow manually running a job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
 name: ci
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 
 jobs:
   build-bookworm:


### PR DESCRIPTION
Since our CI constantly runs against the latest version of Rust, let's allow running a manual CI job so we can run the job on demand to find any new Clippy problems.