### PR TITLE
Fix several clippy warnings

### DIFF
--- a/lawn/src/credential.rs
+++ b/lawn/src/credential.rs
@@ -102,7 +102,7 @@ impl Drop for ConnectionWrapper {
 }
 
 pub enum CredentialObject {
-    Credential(Credential),
+    Credential,
     Store(CredentialStore),
     Vault(CredentialVault),
     Directory(CredentialDirectory),
@@ -233,7 +233,7 @@ impl CredentialClient {
             }
             Some(CredentialPathComponentType::Entry) => {
                 match handle.get_entry_from_path(path).await {
-                    Ok(Some(c)) => Ok(Some(CredentialObject::Credential(c))),
+                    Ok(Some(_)) => Ok(Some(CredentialObject::Credential)),
                     Ok(None) => Ok(None),
                     Err(e) => Err(e),
                 }

--- a/lawn/src/ssh_proxy.rs
+++ b/lawn/src/ssh_proxy.rs
@@ -5,6 +5,7 @@ use num_derive::FromPrimitive;
 use num_traits::FromPrimitive;
 use std::convert::TryInto;
 use std::io;
+use std::mem::MaybeUninit;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
@@ -701,7 +702,9 @@ impl Proxy {
         }
         {
             let slice = unsafe {
-                std::mem::transmute::<_, &mut [u8]>(&mut v.spare_capacity_mut()[0..datalen])
+                std::mem::transmute::<&mut [MaybeUninit<u8>], &mut [u8]>(
+                    &mut v.spare_capacity_mut()[0..datalen],
+                )
             };
             ssh.read_exact(slice).await?;
             unsafe { v.set_len(datalen) };

--- a/lawn/src/store/credential/memory.rs
+++ b/lawn/src/store/credential/memory.rs
@@ -712,7 +712,7 @@ impl CommandCredentialBackend for MemoryCredentialBackend {
             .vaults
             .vaults()
             .ok_or(ResponseCode::NeedsAuthentication)?
-            .write()
+            .read()
             .unwrap();
         let path = elem.path();
         let store_id = elem.store_id();


### PR DESCRIPTION
There are several Clippy warnings with the new version of Rust, so fix these issues to keep it happy.