### PR TITLE
proxy: reserve sufficient capacity

### DIFF
--- a/lawn/src/ssh_proxy.rs
+++ b/lawn/src/ssh_proxy.rs
@@ -697,9 +697,7 @@ impl Proxy {
         }
         let datalen = (len - 1) as usize;
         v.clear();
-        if v.capacity() < datalen {
-            v.reserve(datalen - v.capacity());
-        }
+        v.reserve(datalen);
         {
             let slice = unsafe {
                 std::mem::transmute::<&mut [MaybeUninit<u8>], &mut [u8]>(


### PR DESCRIPTION
The `Vec::reserve` method takes the desired total capacity of the buffer, not the amount to increment it by.  Without this change, large chunks of data, such as 65536-byte messages, can result in a panic due to the 65571-byte range end index being larger than the buffer.

Fix this by reserving the right amount.