### PR TITLE
Makefile: switch to FreeBSD 14

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ ASCIIDOCTOR ?= asciidoctor
 
 CARGO_DEB_VERSION = 1.28.0
 
-FREEBSD_VERSION ?= 13
+FREEBSD_VERSION ?= 14
 NETBSD_VERSION ?= 9
 
 MAN_SRC := $(wildcard doc/man/*.adoc)

--- a/lawn/src/credential.rs
+++ b/lawn/src/credential.rs
@@ -326,6 +326,8 @@ impl CredentialDirectoryHandle {
         }
     }
 
+    // This is used in tests.
+    #[allow(dead_code)]
     async fn get_id(&self) -> Result<StoreSelectorID, CredentialError> {
         match self.id {
             Some(id) => Ok(id),
@@ -707,6 +709,7 @@ impl CredentialStore {
 }
 
 #[async_trait]
+#[allow(dead_code)]
 impl CredentialHandle for CredentialStore {
     async fn authenticate(
         &mut self,

--- a/lawn/src/store.rs
+++ b/lawn/src/store.rs
@@ -137,6 +137,7 @@ impl<T: StoreElement> StoreElementEntry for T {
     }
 }
 
+#[allow(dead_code)]
 pub struct PlainStoreElementEntry {
     store_id: StoreID,
     path: Bytes,


### PR DESCRIPTION
The rust package depends on a newer version of system libraries and therefore fails with this error on FreeBSD 13:

    ld-elf.so.1: /usr/local/bin/../lib/librustc_driver-d829a4d8a572ebe4.so: Undefined symbol "_ZNSt3__122__libcpp_verbose_abortEPKcz"

Switch to FreeBSD 14 to get things working again.

In addition, make sure to fix some new dead code warnings in Rust which are false positives.