### PR TITLE
Blocking I/O

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,7 @@ jobs:
           echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
           sudo udevadm control --reload-rules
           sudo udevadm trigger --name-match=kvm
+    - run: sudo apt-get update
     - run: sudo apt-get -y install vagrant vagrant-libvirt libvirt-daemon-system
     - run: sudo service libvirtd start
     - run: sudo chmod 666 /var/run/libvirt/libvirt-sock
@@ -82,6 +83,7 @@ jobs:
           echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
           sudo udevadm control --reload-rules
           sudo udevadm trigger --name-match=kvm
+    - run: sudo apt-get update
     - run: sudo apt-get -y install vagrant vagrant-libvirt libvirt-daemon-system
     - run: sudo service libvirtd start
     - run: sudo chmod 666 /var/run/libvirt/libvirt-sock

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -360,6 +360,7 @@ dependencies = [
  "num-traits",
  "rand",
  "rand_chacha",
+ "rustix",
  "serde",
  "serde_cbor",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,21 @@
 version = 3
 
 [[package]]
+name = "addr2line"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a30b2e23b9e17a9f90641c7ab1549cd9b44f296d3ccbf309d2863cfe398a0cb"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
 name = "ahash"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -21,7 +36,7 @@ checksum = "b84f9ebcc6c1f5b8cb160f6990096a5c127f423fcb6e1ccc46c370cbdfb75dfc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -29,6 +44,21 @@ name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
+name = "backtrace"
+version = "0.3.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2089b7e3f35b9dd2d0ed921ead4f6d318c27680d4a5bd167b3ee120edb105837"
+dependencies = [
+ "addr2line",
+ "cc",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+]
 
 [[package]]
 name = "base64"
@@ -190,7 +220,7 @@ checksum = "203aadebefcc73d12038296c228eabf830f99cba991b0032adf20e9fa6ce7e4f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -213,6 +243,12 @@ dependencies = [
  "libc",
  "wasi",
 ]
+
+[[package]]
+name = "gimli"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 
 [[package]]
 name = "half"
@@ -428,19 +464,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "log"
-version = "0.4.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
 name = "memchr"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8a240ddb74feaf34a79a7add65a741f3167852fba007066dcac1ca548d89c08"
+dependencies = [
+ "adler",
+]
 
 [[package]]
 name = "mio"
@@ -449,7 +485,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
 dependencies = [
  "libc",
- "log",
  "wasi",
  "windows-sys 0.48.0",
 ]
@@ -462,7 +497,7 @@ checksum = "876a53fff98e03a936a674b29568b0e605f06b29372c2489ff4de23f1949743d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -482,6 +517,15 @@ checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
 dependencies = [
  "hermit-abi 0.1.19",
  "libc",
+]
+
+[[package]]
+name = "object"
+version = "0.32.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6a622008b6e321afc04970976f62ee297fdbaa6f95318ca343e3eebb9648441"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -521,9 +565,9 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.8"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e280fbe77cc62c91527259e9442153f4688736748d24660126286329742b4c6c"
+checksum = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
 
 [[package]]
 name = "ppv-lite86"
@@ -598,6 +642,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-demangle"
+version = "0.1.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
+
+[[package]]
 name = "rustix"
 version = "0.37.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -660,7 +710,7 @@ checksum = "d7e29c4601e36bcec74a223228dce795f4cd3616341a4af93520ca1a837c087d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -724,12 +774,12 @@ checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 
 [[package]]
 name = "socket2"
-version = "0.4.10"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f7916fc008ca5542385b89a3d3ce689953c143e9304a9bf8beec1de48994c0d"
+checksum = "ce305eb0b4296696835b71df73eb912e0f1ffd2556a501fcede6e0c50349191c"
 dependencies = [
  "libc",
- "winapi",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -743,6 +793,17 @@ name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "239814284fd6f1a4ffe4ca893952cdd93c224b6a1571c9a9eadd670295c0c9e2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -788,7 +849,7 @@ checksum = "5420d42e90af0c38c3290abcca25b9b3bdf379fc9f55c528f53a269d9c9a267e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -808,31 +869,31 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.18.5"
+version = "1.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e050c618355082ae5a89ec63bbf897225d5ffe84c7c4e036874e4d185a5044e"
+checksum = "ba4f4a02a7a80d6f274636f0aa95c7e383b912d41fe721a31f29e29698585a4a"
 dependencies = [
+ "backtrace",
  "bytes",
  "libc",
- "memchr",
  "mio",
  "num_cpus",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "winapi",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "1.7.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b557f72f448c511a979e2564e55d74e6c4432fc96ff4f6241bc6bded342643b7"
+checksum = "5f5ae998a069d4b5aba8ee9dad856af7d520c3699e6159b185c2acd48155d39a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -902,28 +963,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
-name = "winapi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
-dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
-]
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
 name = "windows-sys"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -952,6 +991,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
  "windows-targets 0.48.0",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -985,6 +1033,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
 name = "windows_aarch64_gnullvm"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -995,6 +1059,12 @@ name = "windows_aarch64_gnullvm"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -1015,6 +1085,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
 
 [[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
 name = "windows_i686_gnu"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1031,6 +1107,18 @@ name = "windows_i686_gnu"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -1051,6 +1139,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1069,6 +1163,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
 name = "windows_x86_64_gnullvm"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1079,6 +1179,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -1097,6 +1203,12 @@ name = "windows_x86_64_msvc"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "yaml-rust"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -123,6 +123,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53fe5e26ff1b7aef8bca9c6080520cfb8d9333c7568e1829cef191a9723e5504"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -355,6 +364,7 @@ dependencies = [
  "serde_cbor",
  "serde_json",
  "serde_yaml",
+ "sha2",
  "signal-hook-tokio",
  "subtle",
  "tempfile",
@@ -734,6 +744,17 @@ dependencies = [
  "ryu",
  "serde",
  "yaml-rust",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]

--- a/doc/protocol.adoc
+++ b/doc/protocol.adoc
@@ -296,6 +296,7 @@ The following capabilities are known:
 | `channel`   | `clipboard`          | clipboard channels
 | `channel`   | `command`            | command channels
 | `channel`   | `sftp`               | SFTP channels (including all versions of the protocol)
+| `channel`   | `blocking-io`        | blocking I/O support for channels
 | `channel`   | any extension string | Reserved for custom extensions
 
 | `store`     | `credential`         | credential stores
@@ -589,6 +590,9 @@ A read channel request looks like this:
   id: u32,
   selector: u32,
   count: u64,
+  blocking: Option<bool>,
+  stream_sync: Option<u64>,
+  complete: bool,
 }
 ----
 
@@ -596,19 +600,33 @@ The `id` field is the channel ID and the `selector` field is an attached server-
 The `count` field indicates the number of bytes to read.
 Note that this must result in a response that is below the maximum message size.
 
+If both sides implement the `channel=blocking-io` capability, the `blocking` value may be set to `true` to indicate that the I/O is blocking; if it is `null`, the behavior is left to the server to decide, and if it is `false`, non-blocking I/O is requested.
+
+If blocking I/O is explicitly enabled, the `stream_sync` field, which is optional, indicates the starting stream offset on the sending side for this read.
+The request will block until that exact stream offset has been reached.
+If the server detects that the offset has passed, it will send a Conflict response.
+This field is necessary to ensure that multiple in-flight read requests are serviced properly.
+
+If blocking I/O is enabled, the `complete` field, which defaults to false, indicates that the read should not return until the full number of requested bytes has been read, an error occurs, or the stream is at end of file.
+If blocking I/O is enabled and `complete` is false, then a read will complete once _some_ amount of data has been read, an error occurs, or the stream is at end of file.
+Usually this will be whatever data is available to read at the moment.
+
 On success, a response looks like this:
 
 ----
 {
   bytes: Bytes,
+  offset: Option<u64>,
 }
 ----
 
 The `bytes` field contains the bytes read, which may be shorter than desired.
 If the field contains no data, then this means that end-of-file has been reached.
 
-Note that the read is non-blocking.
-If end-of-file has not been reached but there is no data to immediately read, the Errno response will be sent with an error code indicating EAGAIN.
+The `offset` field, which is only available if `stream_sync` is set (and thus, only available with blocking I/O), contains the value of `stream_sync`, which can be used to associate responses efficiently with their requests.
+This will always be the starting offset of the read.
+
+If end-of-file has not been reached but there is no data to immediately read and blocking I/O is not enabled, the Errno response will be sent with an error code indicating EAGAIN.
 Other errors may be indicated, either with an Errno response or otherwise.
 
 This message requires authentication.
@@ -624,22 +642,39 @@ A write channel request looks like this:
   id: u32,
   selector: u32,
   bytes: Bytes,
+  blocking: Option<bool>,
+  stream_sync: Option<u64>,
 }
 ----
 
 The `id` field is the channel ID and the `selector` field is an attached client-to-server selector on that channel.
 `bytes` is the data to write.
 
+If both sides implement the `channel=blocking-io` capability, the `blocking` value may be set to `true` to indicate that the I/O is blocking; if it is `null`, the behavior is left to the server to decide, and if it is `false`, non-blocking I/O is requested.
+
+If blocking I/O is explicitly enabled, the `stream_sync` field, which is optional, indicates the starting stream offset on the sending side for this write.
+The request will block until that exact stream offset has been reached.
+If the server detects that the offset has passed, it will send a Conflict response.
+This field is necessary to ensure that multiple in-flight write requests are serviced properly.
+
+If blocking I/O is enabled, a write will return when the entire payload has been written or an error occurs.
+
 On success, the response looks like this:
 
 ----
 {
   count: u64,
+  offset: Option<u64>,
 }
 ----
 
-Note that the write is non-blocking, and short writes may occur.
-If the data cannot be immediately written, the Errno response will be sent with an error code indicating EAGAIN.
+The `count` field indicates the number of bytes written.
+
+The `offset` field, which is only available if `stream_sync` is set (and thus, only available with blocking I/O), contains the value of `stream_sync`, which can be used to associate responses efficiently with their requests.
+This will always be the starting offset of the write.
+
+Note that short writes may occur.
+If blocking I/O is not enabled and the data cannot be immediately written, the Errno response will be sent with an error code indicating EAGAIN.
 Other errors may be indicated, either with an Errno response or otherwise.
 
 This message requires authentication.

--- a/doc/protocol.adoc
+++ b/doc/protocol.adoc
@@ -295,6 +295,7 @@ The following capabilities are known:
 | `channel`   | `9p`                 | 9P channels (including all variants of the protocol)
 | `channel`   | `clipboard`          | clipboard channels
 | `channel`   | `command`            | command channels
+| `channel`   | `sftp`               | SFTP channels (including all versions of the protocol)
 | `channel`   | any extension string | Reserved for custom extensions
 
 | `store`     | `credential`         | credential stores
@@ -455,6 +456,7 @@ The following channel types are known:
 |  `9p`                 | channels for the 9P2000, 9P2000.u, and 9P2000.L protocols
 |  `clipboard`          | channels for clipboard operations
 |  `command`            | channels for commands
+|  `sftp`               | channels for the SFTP protocol
 |  any extension string | Reserved for custom extensions
 
 |===
@@ -498,6 +500,23 @@ In order to crate a channel of this type, the `channel=9p` protocol must be impl
 The `kind` field contains `9p`.
 The `selectors` field should indicate the selectors 0 and 1.
 Selector 0 indicates a unidirectional tunnel from 9P client to 9P server and selector 1 indicates a unidirectional tunnel from 9P server to 9P client.
+
+The `kind-args` and `meta` fields are null or absent.
+
+The `args` field should contain a single argument, the name of the file system share to mount.
+The `env` field, if present, should contain the environment variables of the client.
+If the client only supports Unicode environment variables, they MUST be encoded as UTF-8 without a BOM (unless a BOM is part of the data).
+
+===== SFTP Channels
+
+An SFTP channel is used for sending messages using the SFTP file system protocol and its variants.
+The specific variant is negotiated using the SFTP protocol itself, but support for version 3 is RECOMMENDED, since this is the most commonly implemented variant.
+
+In order to crate a channel of this type, the `channel=sftp` protocol must be implemented by both sides.
+
+The `kind` field contains `sftp`.
+The `selectors` field should indicate the selectors 0 and 1.
+Selector 0 indicates a unidirectional tunnel from SFTP client to SFTP server and selector 1 indicates a unidirectional tunnel from SFTP server to SFTP client.
 
 The `kind-args` and `meta` fields are null or absent.
 

--- a/lawn-protocol/src/protocol/mod.rs
+++ b/lawn-protocol/src/protocol/mod.rs
@@ -552,7 +552,7 @@ pub struct DeleteChannelRequest {
     pub termination: Option<u32>,
 }
 
-#[derive(Serialize, Deserialize, Hash, Eq, PartialEq, Ord, PartialOrd, Clone)]
+#[derive(Serialize, Deserialize, Debug, Hash, Eq, PartialEq, Ord, PartialOrd, Clone)]
 #[serde(rename_all = "kebab-case")]
 pub struct ReadChannelRequest {
     pub id: ChannelID,
@@ -566,7 +566,7 @@ pub struct ReadChannelRequest {
     pub complete: bool,
 }
 
-#[derive(Serialize, Deserialize, Hash, Eq, PartialEq, Ord, PartialOrd, Clone)]
+#[derive(Serialize, Deserialize, Debug, Hash, Eq, PartialEq, Ord, PartialOrd, Clone)]
 #[serde(rename_all = "kebab-case")]
 pub struct ReadChannelResponse {
     pub bytes: Bytes,
@@ -574,7 +574,7 @@ pub struct ReadChannelResponse {
     pub offset: Option<u64>,
 }
 
-#[derive(Serialize, Deserialize, Hash, Eq, PartialEq, Ord, PartialOrd, Clone)]
+#[derive(Serialize, Deserialize, Debug, Hash, Eq, PartialEq, Ord, PartialOrd, Clone)]
 #[serde(rename_all = "kebab-case")]
 pub struct WriteChannelRequest {
     pub id: ChannelID,
@@ -586,7 +586,7 @@ pub struct WriteChannelRequest {
     pub blocking: Option<bool>,
 }
 
-#[derive(Serialize, Deserialize, Hash, Eq, PartialEq, Ord, PartialOrd, Clone)]
+#[derive(Serialize, Deserialize, Debug, Hash, Eq, PartialEq, Ord, PartialOrd, Clone)]
 #[serde(rename_all = "kebab-case")]
 pub struct WriteChannelResponse {
     pub count: u64,
@@ -1604,5 +1604,79 @@ mod tests {
             },
             b"\xa3\x69extension\x82\x58\x23foobar@test.ns.crustytoothpaste.net\xf6\x58\x26extension@test.ns.crustytoothpaste.net\xf5\x65count\x05",
         );
+    }
+
+    #[test]
+    fn deserialize_requests_rw_compatible() {
+        #[derive(Serialize, Deserialize, Debug, Hash, Eq, PartialEq, Ord, PartialOrd, Clone)]
+        #[serde(rename_all = "kebab-case")]
+        struct ReadChannelLegacyRequest {
+            pub id: ChannelID,
+            pub selector: u32,
+            pub count: u64,
+        }
+
+        let cases: &[(&[u8], &str)] = &[
+            (b"\xa3\x62id\x00\x68selector\x02\x65count\x1a\xfe\xdc\xba\x98", "legacy"),
+            (b"\xa6\x62id\x00\x68selector\x02\x65count\x1a\xfe\xdc\xba\x98\x6bstream-sync\xf6\x68blocking\xf6\x68complete\xf4", "modern"),
+        ];
+        for (b, desc) in cases {
+            assert_decode(
+                &format!("ReadChannelRequest without blocking I/O: {}", desc),
+                &super::ReadChannelRequest {
+                    id: ChannelID(0),
+                    selector: 2,
+                    count: 0xfedcba98,
+                    stream_sync: None,
+                    blocking: None,
+                    complete: false,
+                },
+                b,
+            );
+            assert_decode(
+                &format!("ReadChannelRequest (legacy): {}", desc),
+                &ReadChannelLegacyRequest {
+                    id: ChannelID(0),
+                    selector: 2,
+                    count: 0xfedcba98,
+                },
+                b,
+            );
+        }
+
+        #[derive(Serialize, Deserialize, Debug, Hash, Eq, PartialEq, Ord, PartialOrd, Clone)]
+        #[serde(rename_all = "kebab-case")]
+        struct WriteChannelLegacyRequest {
+            pub id: ChannelID,
+            pub selector: u32,
+            pub bytes: Bytes,
+        }
+
+        let cases: &[(&[u8], &str)] = &[
+            (b"\xa3\x62id\x00\x68selector\x02\x65bytes\x44\xff\xfe\xc2\xa9", "legacy"),
+            (b"\xa5\x62id\x00\x68selector\x02\x65bytes\x44\xff\xfe\xc2\xa9\x6bstream-sync\xf6\x68blocking\xf6", "modern"),
+        ];
+        for (b, desc) in cases {
+            assert_decode(
+                &format!("WriteChannelRequest without blocking I/O: {}", desc),
+                &super::WriteChannelRequest {
+                    id: ChannelID(0),
+                    selector: 2,
+                    bytes: vec![0xffu8, 0xfe, 0xc2, 0xa9].into(),
+                    stream_sync: None,
+                    blocking: None,
+                },
+                b,
+            );
+            assert_decode(
+                &format!("WriteChannelRequest (legacy): {}", desc),
+                &WriteChannelLegacyRequest {
+                    id: ChannelID(0),
+                    selector: 2,
+                    bytes: vec![0xffu8, 0xfe, 0xc2, 0xa9].into(),
+                },
+                b,
+            );
+        }
     }
 }

--- a/lawn-protocol/src/protocol/mod.rs
+++ b/lawn-protocol/src/protocol/mod.rs
@@ -568,6 +568,8 @@ pub struct ReadChannelRequest {
 #[serde(rename_all = "kebab-case")]
 pub struct ReadChannelResponse {
     pub bytes: Bytes,
+    #[serde(default)]
+    pub offset: Option<u64>,
 }
 
 #[derive(Serialize, Deserialize, Hash, Eq, PartialEq, Ord, PartialOrd, Clone)]
@@ -586,6 +588,8 @@ pub struct WriteChannelRequest {
 #[serde(rename_all = "kebab-case")]
 pub struct WriteChannelResponse {
     pub count: u64,
+    #[serde(default)]
+    pub offset: Option<u64>,
 }
 
 #[derive(Serialize, Deserialize, Hash, Eq, PartialEq, Ord, PartialOrd, Clone)]

--- a/lawn-protocol/src/protocol/mod.rs
+++ b/lawn-protocol/src/protocol/mod.rs
@@ -562,6 +562,8 @@ pub struct ReadChannelRequest {
     pub stream_sync: Option<u64>,
     #[serde(default)]
     pub blocking: Option<bool>,
+    #[serde(default)]
+    pub complete: bool,
 }
 
 #[derive(Serialize, Deserialize, Hash, Eq, PartialEq, Ord, PartialOrd, Clone)]

--- a/lawn-protocol/src/protocol/mod.rs
+++ b/lawn-protocol/src/protocol/mod.rs
@@ -323,6 +323,7 @@ pub enum Capability {
     Channel9P,
     ChannelSFTP,
     ChannelClipboard,
+    ChannelBlockingIO,
     ExtensionAllocate,
     StoreCredential,
     ContextTemplate,
@@ -340,6 +341,7 @@ impl Capability {
             Self::ChannelClipboard,
             Self::Channel9P,
             Self::ChannelSFTP,
+            Self::ChannelBlockingIO,
             Self::ExtensionAllocate,
             Self::StoreCredential,
             Self::ContextTemplate,
@@ -359,6 +361,7 @@ impl Capability {
                 | Self::ChannelClipboard
                 | Self::Channel9P
                 | Self::ChannelSFTP
+                | Self::ChannelBlockingIO
                 | Self::ExtensionAllocate
                 | Self::StoreCredential
                 | Self::ContextTemplate
@@ -391,6 +394,10 @@ impl From<Capability> for (Bytes, Option<Bytes>) {
                 (b"channel" as &[u8]).into(),
                 Some((b"clipboard" as &[u8]).into()),
             ),
+            Capability::ChannelBlockingIO => (
+                (b"channel" as &[u8]).into(),
+                Some((b"blocking-io" as &[u8]).into()),
+            ),
             Capability::StoreCredential => (
                 (b"store" as &[u8]).into(),
                 Some((b"credential" as &[u8]).into()),
@@ -418,6 +425,7 @@ impl From<(&[u8], Option<&[u8]>)> for Capability {
             (b"channel", Some(b"9p")) => Capability::Channel9P,
             (b"channel", Some(b"sftp")) => Capability::ChannelSFTP,
             (b"channel", Some(b"clipboard")) => Capability::ChannelClipboard,
+            (b"channel", Some(b"blocking-io")) => Capability::ChannelBlockingIO,
             (b"store", Some(b"credential")) => Capability::StoreCredential,
             (b"extension", Some(b"allocate")) => Capability::ExtensionAllocate,
             (b"context", Some(b"template")) => Capability::ContextTemplate,
@@ -550,6 +558,10 @@ pub struct ReadChannelRequest {
     pub id: ChannelID,
     pub selector: u32,
     pub count: u64,
+    #[serde(default)]
+    pub stream_sync: Option<u64>,
+    #[serde(default)]
+    pub blocking: Option<bool>,
 }
 
 #[derive(Serialize, Deserialize, Hash, Eq, PartialEq, Ord, PartialOrd, Clone)]
@@ -564,6 +576,10 @@ pub struct WriteChannelRequest {
     pub id: ChannelID,
     pub selector: u32,
     pub bytes: Bytes,
+    #[serde(default)]
+    pub stream_sync: Option<u64>,
+    #[serde(default)]
+    pub blocking: Option<bool>,
 }
 
 #[derive(Serialize, Deserialize, Hash, Eq, PartialEq, Ord, PartialOrd, Clone)]

--- a/lawn/Cargo.toml
+++ b/lawn/Cargo.toml
@@ -51,3 +51,4 @@ hex = "0.4"
 
 [dev-dependencies]
 tempfile = "3"
+sha2 = "0.10"

--- a/lawn/Cargo.toml
+++ b/lawn/Cargo.toml
@@ -39,6 +39,7 @@ lawn-protocol = { path = "../lawn-protocol", version = "0.4.0", features = ["asy
 lawn-sftp = { path = "../lawn-sftp", version = "0.4.0" }
 rand = "0.8"
 rand_chacha = "0.3"
+rustix = { version = "0.37", features = ["termios"] }
 subtle = "2"
 tokio = { version = "1", features = [ "io-std", "macros", "net", "process", "rt", "rt-multi-thread", "signal", "time" ] }
 tokio-pipe = "0.2"

--- a/lawn/src/main.rs
+++ b/lawn/src/main.rs
@@ -838,8 +838,14 @@ fn dispatch_clip(
             .await?;
         let _ = conn.negotiate_default_version().await;
         let _ = conn.auth_external().await;
-        conn.run_clipboard(tokio::io::stdin(), tokio::io::stdout(), op, target)
-            .await
+        conn.run_clipboard(
+            tokio::io::stdin(),
+            tokio::io::stdout(),
+            rustix::termios::isatty(io::stdout()),
+            op,
+            target,
+        )
+        .await
     })?;
     std::process::exit(res);
 }
@@ -876,6 +882,7 @@ fn dispatch_run(
             tokio::io::stdin(),
             tokio::io::stdout(),
             tokio::io::stderr(),
+            rustix::termios::isatty(io::stdout()),
         )
         .await
     })?;

--- a/lawn/src/server.rs
+++ b/lawn/src/server.rs
@@ -938,9 +938,12 @@ impl Server {
                 };
                 let selector = m.selector;
                 let count = m.count;
-                let data = tokio::task::spawn_blocking(move || ch.read(selector, count))
-                    .await
-                    .unwrap()?;
+                let sync = m.stream_sync;
+                let blocking = m.blocking;
+                let data =
+                    tokio::task::spawn_blocking(move || ch.read(selector, count, sync, blocking))
+                        .await
+                        .unwrap()?;
                 let resp = protocol::ReadChannelResponse { bytes: data };
                 Ok((ResponseType::Success, serializer.serialize_body(&resp)))
             }
@@ -954,9 +957,12 @@ impl Server {
                 };
                 let selector = m.selector;
                 let bytes = m.bytes;
-                let n = tokio::task::spawn_blocking(move || ch.write(selector, bytes))
-                    .await
-                    .unwrap()?;
+                let sync = m.stream_sync;
+                let blocking = m.blocking;
+                let n =
+                    tokio::task::spawn_blocking(move || ch.write(selector, bytes, sync, blocking))
+                        .await
+                        .unwrap()?;
                 let resp = protocol::WriteChannelResponse { count: n };
                 Ok((ResponseType::Success, serializer.serialize_body(&resp)))
             }

--- a/lawn/src/server.rs
+++ b/lawn/src/server.rs
@@ -941,6 +941,9 @@ impl Server {
                 let sync = m.stream_sync;
                 let blocking = m.blocking;
                 let complete = m.complete;
+                if sync.is_some() || blocking.is_some() || complete {
+                    assert_capability!(handler, protocol::Capability::ChannelBlockingIO);
+                }
                 let data = tokio::task::spawn_blocking(move || {
                     ch.read(selector, count, sync, blocking, complete)
                 })
@@ -964,6 +967,9 @@ impl Server {
                 let bytes = m.bytes;
                 let sync = m.stream_sync;
                 let blocking = m.blocking;
+                if sync.is_some() || blocking.is_some() {
+                    assert_capability!(handler, protocol::Capability::ChannelBlockingIO);
+                }
                 let n =
                     tokio::task::spawn_blocking(move || ch.write(selector, bytes, sync, blocking))
                         .await

--- a/lawn/src/server.rs
+++ b/lawn/src/server.rs
@@ -944,7 +944,10 @@ impl Server {
                     tokio::task::spawn_blocking(move || ch.read(selector, count, sync, blocking))
                         .await
                         .unwrap()?;
-                let resp = protocol::ReadChannelResponse { bytes: data };
+                let resp = protocol::ReadChannelResponse {
+                    bytes: data,
+                    offset: sync,
+                };
                 Ok((ResponseType::Success, serializer.serialize_body(&resp)))
             }
             Some(MessageKind::WriteChannel) => {
@@ -963,7 +966,10 @@ impl Server {
                     tokio::task::spawn_blocking(move || ch.write(selector, bytes, sync, blocking))
                         .await
                         .unwrap()?;
-                let resp = protocol::WriteChannelResponse { count: n };
+                let resp = protocol::WriteChannelResponse {
+                    count: n,
+                    offset: sync,
+                };
                 Ok((ResponseType::Success, serializer.serialize_body(&resp)))
             }
             Some(MessageKind::DeleteChannel) => {

--- a/lawn/src/server.rs
+++ b/lawn/src/server.rs
@@ -940,10 +940,12 @@ impl Server {
                 let count = m.count;
                 let sync = m.stream_sync;
                 let blocking = m.blocking;
-                let data =
-                    tokio::task::spawn_blocking(move || ch.read(selector, count, sync, blocking))
-                        .await
-                        .unwrap()?;
+                let complete = m.complete;
+                let data = tokio::task::spawn_blocking(move || {
+                    ch.read(selector, count, sync, blocking, complete)
+                })
+                .await
+                .unwrap()?;
                 let resp = protocol::ReadChannelResponse {
                     bytes: data,
                     offset: sync,

--- a/lawn/src/tests.rs
+++ b/lawn/src/tests.rs
@@ -1270,7 +1270,9 @@ fn test_data_streaming(ti: Arc<TestInstance>) {
         ];
 
         assert_eq!(
-            c.run_command(args, input, stdout, stderr).await.unwrap(),
+            c.run_command(args, input, stdout, stderr, false)
+                .await
+                .unwrap(),
             0,
             "exit status of command is 0"
         );
@@ -1433,8 +1435,8 @@ fn test_out_of_order_packets(ti: Arc<TestInstance>) {
         std::mem::drop(msgtx);
         msgproc.await.unwrap();
         c.clone().detach_channel_selector(id, 0).await;
-        let stdout_task = c.clone().io_channel_read_task(id, 1, stdout);
-        let stderr_task = c.clone().io_channel_read_task(id, 2, stderr);
+        let stdout_task = c.clone().io_channel_read_task(id, 1, true, stdout);
+        let stderr_task = c.clone().io_channel_read_task(id, 2, false, stderr);
         finalrx.recv().await.unwrap().unwrap();
         let _ = tokio::join!(stdout_task, stderr_task, unwrapper);
         let outbuf = tokio::fs::read(&outpathbuf).await.unwrap();

--- a/lawn/src/tests.rs
+++ b/lawn/src/tests.rs
@@ -116,7 +116,9 @@ impl TestInstance {
         let mut builder = builder.unwrap_or_else(|| ConfigBuilder::new());
         builder.env(move |s| env.env(s), move || iterenv.iter());
         builder.create_runtime_dir(false);
-        builder.verbosity(5);
+        if std::env::var_os("LAWN_TEST_VERBOSE").is_some() {
+            builder.verbosity(5);
+        }
         builder.stdout(Box::new(io::Cursor::new(Vec::new())));
         builder.stderr(Box::new(io::stdout()));
         builder.config_file(&config_file);

--- a/spec/fixtures/bin/randomgen
+++ b/spec/fixtures/bin/randomgen
@@ -1,0 +1,33 @@
+#!/usr/bin/env ruby
+
+require 'openssl'
+require 'optparse'
+
+if ARGV.length > 0
+  outputlen = ARGV[0].to_i
+else
+  outputlen = 65536
+end
+
+hash = OpenSSL::Digest.new('SHA384')
+
+while buf = $stdin.read(1024)
+  hash << buf
+end
+
+digest = hash.digest
+
+cipher = OpenSSL::Cipher.new 'aes-256-ctr'
+cipher.encrypt
+cipher.key = digest[0...32]
+cipher.iv = digest[32..]
+
+zeros = "\x00" * 1024
+
+written = 0
+while written < outputlen
+  last = [outputlen - written, zeros.length].min
+  output = cipher.update zeros
+  print output[0...last]
+  written += last
+end


### PR DESCRIPTION
Right now, if it isn't immediately possible to perform a read or write, we get an `EAGAIN`, and we must poll to find out when the selector is ready, and then try again.  This adds two whole additional round trips to our request, and can make things much slower than they need to be.

Add a capability to allow using blocking I/O, optionally with multiple requests in flight at a time, to improve throughput, and use it to send multiple write requests over a channel at once.