### PR TITLE
Fix some more clippy warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,6 +94,7 @@ jobs:
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     steps:
     - uses: actions/checkout@v3
+    - run: brew unlink pkg-config@0.29.2 || true
     - run: brew install ruby asciidoctor rust
     - run: gem install rspec
     - run: mkdir ~/tmp

--- a/lawn-protocol/src/protocol/mod.rs
+++ b/lawn-protocol/src/protocol/mod.rs
@@ -1201,10 +1201,9 @@ impl ProtocolSerializer {
         b.extend(&size.to_le_bytes());
         b.extend(&msg.id.to_le_bytes());
         b.extend(&msg.kind.to_le_bytes());
-        match &msg.message {
-            Some(m) => b.extend(m),
-            None => (),
-        };
+        if let Some(m) = &msg.message {
+            b.extend(m);
+        }
         Some(b.into())
     }
 
@@ -1247,10 +1246,9 @@ impl ProtocolSerializer {
         b.extend(&size.to_le_bytes());
         b.extend(&resp.id.to_le_bytes());
         b.extend(&resp.code.to_le_bytes());
-        match &resp.message {
-            Some(m) => b.extend(m),
-            None => (),
-        };
+        if let Some(m) = &resp.message {
+            b.extend(m);
+        }
         Some(b.into())
     }
 

--- a/lawn/src/config.rs
+++ b/lawn/src/config.rs
@@ -1256,6 +1256,7 @@ impl<'a> ConfigValue<'a> {
         }
     }
 
+    #[allow(clippy::manual_pattern_char_comparison)]
     fn into_string(self) -> Result<String, Error> {
         let s = match self.value {
             Value::String(ref s) => s,

--- a/lawn/src/store/credential/helpers.rs
+++ b/lawn/src/store/credential/helpers.rs
@@ -63,8 +63,8 @@ impl<
     }
 }
 
-impl<T: Send + Sync, U: CommandCredentialBackend<Backend = T> + Sized + Send + Sync + ?Sized>
-    StoreElement for CommandCredentialVault<T, U>
+impl<T: Send + Sync, U: CommandCredentialBackend<Backend = T> + Sized + Send + Sync> StoreElement
+    for CommandCredentialVault<T, U>
 {
     fn store_id(&self) -> StoreID {
         self.store_id


### PR DESCRIPTION
Fix some uses of `match` where `let Some` will do and a usage of `Sized` and `?Sized` at the same time.  Additionally, disable a lint that uses syntax from 1.81, when we're targeting 1.63.