### PR TITLE
More clippy fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -502,13 +502,13 @@ dependencies = [
 
 [[package]]
 name = "num-derive"
-version = "0.3.3"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "876a53fff98e03a936a674b29568b0e605f06b29372c2489ff4de23f1949743d"
+checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.32",
 ]
 
 [[package]]

--- a/lawn-9p/Cargo.toml
+++ b/lawn-9p/Cargo.toml
@@ -23,7 +23,7 @@ flurry = "0.4"
 libc = "0.2"
 bitflags = "1.3"
 num-traits = "0.2"
-num-derive = "0.3"
+num-derive = "0.4"
 tokio = { version = "1", features = [ "io-std", "io-util", "macros", "net", "process", "rt", "rt-multi-thread", "signal", "sync", "time" ] }
 rustix = { version = "0.37", optional = true }
 

--- a/lawn-constants/Cargo.toml
+++ b/lawn-constants/Cargo.toml
@@ -18,5 +18,5 @@ rust-version = "1.63.0"
 [dependencies]
 libc = "0.2"
 rustix = { version = "0.37", optional = true }
-num-derive = "0.3"
+num-derive = "0.4"
 num-traits = "0.2"

--- a/lawn-constants/src/logger.rs
+++ b/lawn-constants/src/logger.rs
@@ -110,7 +110,7 @@ pub enum LogStr<'a> {
     Bytes(&'a [u8]),
 }
 
-impl<'a> fmt::Display for LogStr<'a> {
+impl fmt::Display for LogStr<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         use std::fmt::Write;
         match self {
@@ -128,7 +128,7 @@ impl<'a> fmt::Display for LogStr<'a> {
     }
 }
 
-impl<'a> fmt::Debug for LogStr<'a> {
+impl fmt::Debug for LogStr<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         fmt::Display::fmt(self, f)
     }
@@ -138,7 +138,7 @@ pub enum HexLogStr<'a> {
     Bytes(&'a [u8]),
 }
 
-impl<'a> fmt::Display for HexLogStr<'a> {
+impl fmt::Display for HexLogStr<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         match self {
             Self::Bytes(arr) => {
@@ -151,7 +151,7 @@ impl<'a> fmt::Display for HexLogStr<'a> {
     }
 }
 
-impl<'a> fmt::Debug for HexLogStr<'a> {
+impl fmt::Debug for HexLogStr<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         fmt::Display::fmt(self, f)
     }

--- a/lawn-fs/Cargo.toml
+++ b/lawn-fs/Cargo.toml
@@ -22,7 +22,7 @@ flurry = "0.4"
 rustix = { version = "0.37", features = ["fs", "process"], optional = true }
 bitflags = "1.3"
 num-traits = "0.2"
-num-derive = "0.3"
+num-derive = "0.4"
 
 [dev-dependencies]
 tempfile = "3"

--- a/lawn-fs/src/auth.rs
+++ b/lawn-fs/src/auth.rs
@@ -1,6 +1,3 @@
-use crate::backend::Metadata;
-use lawn_constants::Error;
-
 /// A set of tools to implement authentication and location finding.
 ///
 /// Each authenticator is responsible for determining whether and what access is to be granted,
@@ -8,7 +5,9 @@ use lawn_constants::Error;
 /// root of the mount.
 ///
 /// This is done by creating an instance of the `Authenticator` trait, which can create handles,
-/// and then
+/// and then passing it to the backend in question.
+use crate::backend::Metadata;
+use lawn_constants::Error;
 
 type Result<T> = std::result::Result<T, Error>;
 

--- a/lawn-protocol/Cargo.toml
+++ b/lawn-protocol/Cargo.toml
@@ -23,7 +23,7 @@ serde_cbor = "0.11.2"
 bytes = { version = "1", features = ["serde"] }
 tokio = { version = "1", features = ["fs", "sync", "io-util"], optional = true }
 num-traits = "0.2"
-num-derive = "0.3"
+num-derive = "0.4"
 lawn-constants = { path = "../lawn-constants", version = "0.4.0" }
 
 [features]

--- a/lawn-protocol/src/protocol/mod.rs
+++ b/lawn-protocol/src/protocol/mod.rs
@@ -1,16 +1,4 @@
 #![allow(non_upper_case_globals)]
-use crate::config::Config;
-use bitflags::bitflags;
-use bytes::{Bytes, BytesMut};
-use num_traits::FromPrimitive;
-use serde::{de::DeserializeOwned, Deserialize, Serialize};
-use serde_cbor::Value;
-use std::collections::{BTreeMap, BTreeSet};
-use std::convert::{TryFrom, TryInto};
-use std::fmt;
-use std::io;
-use std::io::{Seek, SeekFrom};
-
 /// # Overview
 ///
 /// The protocol is relatively simple.  Each request consists of a 32-bit size of the resulting
@@ -46,6 +34,17 @@ use std::io::{Seek, SeekFrom};
 /// `0xfff001000`,  and so on.  This provides 4096 codes per extension while
 /// allowing 4096 extensions.  However, this algorithm is subject to change at any
 /// time.
+use crate::config::Config;
+use bitflags::bitflags;
+use bytes::{Bytes, BytesMut};
+use num_traits::FromPrimitive;
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use serde_cbor::Value;
+use std::collections::{BTreeMap, BTreeSet};
+use std::convert::{TryFrom, TryInto};
+use std::fmt;
+use std::io;
+use std::io::{Seek, SeekFrom};
 
 /// The response codes for the protocol.
 ///

--- a/lawn-sftp/Cargo.toml
+++ b/lawn-sftp/Cargo.toml
@@ -22,7 +22,7 @@ hex = "0.4"
 flurry = "0.4"
 bitflags = "1.3"
 num-traits = "0.2"
-num-derive = "0.3"
+num-derive = "0.4"
 tokio = { version = "1", features = [ "io-std", "io-util", "macros", "net", "process", "rt", "rt-multi-thread", "signal", "sync", "time" ] }
 
 [dev-dependencies]

--- a/lawn/Cargo.toml
+++ b/lawn/Cargo.toml
@@ -47,7 +47,7 @@ thiserror = "1.0.39"
 url = "2.2"
 daemonize = "0.5"
 num-traits = "0.2"
-num-derive = "0.3"
+num-derive = "0.4"
 hex = "0.4"
 
 [dev-dependencies]

--- a/lawn/src/ssh_proxy.rs
+++ b/lawn/src/ssh_proxy.rs
@@ -91,7 +91,7 @@ struct BorrowedSSHMessage<'a> {
 }
 
 #[async_trait]
-impl<'a> Writable for BorrowedSSHMessage<'a> {
+impl Writable for BorrowedSSHMessage<'_> {
     async fn write_full<W: AsyncWriteExt + Unpin + Send>(&self, w: &mut W) -> io::Result<()> {
         let lenbuf = self.len.to_be_bytes();
         let data = [&lenbuf, std::slice::from_ref(&self.kind), &self.data];


### PR DESCRIPTION
Fix several Clippy warnings, including by omitting an anonymous lifetime, updating the `num-derive` crate, and fixing a misplaced comment.