### PR TITLE
Remove BSD CI jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,45 +49,6 @@ jobs:
       with:
         ruby-version: 3.1
     - run: make ci-stable
-  build-freebsd:
-    name: FreeBSD
-    runs-on: ubuntu-latest
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
-    steps:
-    - uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
-    - uses: ruby/setup-ruby@v1
-      with:
-        ruby-version: 3.1
-    - name: Enable KVM group perms
-      run: |
-          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
-          sudo udevadm control --reload-rules
-          sudo udevadm trigger --name-match=kvm
-    - run: sudo apt-get update
-    - run: sudo apt-get -y install vagrant vagrant-libvirt libvirt-daemon-system
-    - run: sudo service libvirtd start
-    - run: sudo chmod 666 /var/run/libvirt/libvirt-sock
-    - run: make ci-freebsd
-  build-netbsd:
-    name: NetBSD
-    runs-on: ubuntu-latest
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
-    steps:
-    - uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
-    - name: Enable KVM group perms
-      run: |
-          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
-          sudo udevadm control --reload-rules
-          sudo udevadm trigger --name-match=kvm
-    - run: sudo apt-get update
-    - run: sudo apt-get -y install vagrant vagrant-libvirt libvirt-daemon-system
-    - run: sudo service libvirtd start
-    - run: sudo chmod 666 /var/run/libvirt/libvirt-sock
-    - run: make ci-netbsd
   build-mac:
     name: macOS
     runs-on: macos-latest


### PR DESCRIPTION
Vagrant has changed its license to a non-free one.  As a result, it has been removed from Ubuntu 24.04, which is now the default on GitHub Actions.  For now, remove the BSD CI jobs until we can find an alternate option.