### PR TITLE
Clippy and CI fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,18 +14,13 @@ jobs:
     - run: make ci-bookworm
   build-bookworm-arm64:
     name: Linux (Debian bookworm arm64)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     steps:
     - uses: actions/checkout@v3
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: 3.1
-    - run: |
-        echo '{"experimental": true}' | sudo tee /etc/docker/daemon.json
-        sudo systemctl restart docker.service
-        docker version -f '{{.Server.Experimental}}'
-    - uses: docker/setup-qemu-action@v2
     - run: make ci-bookworm
       env:
         PLATFORM: linux/arm64

--- a/lawn/src/config.rs
+++ b/lawn/src/config.rs
@@ -1226,7 +1226,7 @@ impl<'a> ConfigValue<'a> {
                 format!("command {} must start with a !", s),
             ));
         }
-        let t = Template::new(s[1..].as_bytes());
+        let t = Template::new(&s.as_bytes()[1..]);
         t.expand(context).map_err(|e| {
             Error::new_full(
                 ErrorKind::TemplateError,
@@ -1468,7 +1468,7 @@ impl<'a> Command<'a> {
                 format!("command {} must start with a !", s),
             ));
         }
-        let t = Template::new(s[1..].as_bytes());
+        let t = Template::new(&s.as_bytes()[1..]);
         t.expand(context).map_err(|e| {
             Error::new_full(
                 ErrorKind::TemplateError,


### PR DESCRIPTION
Fix a clippy warning about the order of slicing and converting to bytes, as well as speeding up CI by using a native arm64 runner.