### PR TITLE
Update tokio to 1.38.2 for GHSA-rr8g-9fpq-6wmg

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -912,9 +912,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.38.0"
+version = "1.38.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba4f4a02a7a80d6f274636f0aa95c7e383b912d41fe721a31f29e29698585a4a"
+checksum = "68722da18b0fc4a05fdc1120b302b82051265792a1e1b399086e9b204b10ad3d"
 dependencies = [
  "backtrace",
  "bytes",


### PR DESCRIPTION
This version fixes a security update but retains the 1.63.0 compatibility.