### PR TITLE
Re-add support for `--help` output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -119,6 +119,9 @@ checksum = "a7db700bc935f9e43e88d00b0850dae18a63773cfbec6d8e070fccf7fef89a39"
 dependencies = [
  "bitflags",
  "clap_lex",
+ "is-terminal",
+ "strsim",
+ "termcolor",
 ]
 
 [[package]]
@@ -295,6 +298,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
 
 [[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -359,6 +368,17 @@ dependencies = [
  "hermit-abi 0.3.1",
  "libc",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "is-terminal"
+version = "0.4.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
+dependencies = [
+ "hermit-abi 0.5.2",
+ "libc",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -840,6 +860,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
 name = "subtle"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -878,6 +904,15 @@ dependencies = [
  "redox_syscall 0.3.5",
  "rustix",
  "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -1015,6 +1050,15 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "windows-sys"

--- a/lawn/Cargo.toml
+++ b/lawn/Cargo.toml
@@ -24,7 +24,7 @@ async-trait = "= 0.1.66"
 base64 = "0.21"
 blake2 = "0.10"
 bytes = "1"
-clap = { version = "= 4.0", default-features = false, features = ["std"] }
+clap = { version = "= 4.0" }
 serde = { version = "1.0", features = ["derive"] }
 serde_cbor = "0.11"
 serde_json = "1.0"

--- a/lawn/src/channel.rs
+++ b/lawn/src/channel.rs
@@ -592,10 +592,7 @@ impl ServerCommandChannel {
         cmd.stdout(Stdio::piped());
         cmd.stderr(Stdio::piped());
         trace!(logger, "channel {}: spawn {:?}", id, cmd);
-        let mut cmd = match cmd.spawn() {
-            Ok(cmd) => cmd,
-            Err(e) => return Err(e.into()),
-        };
+        let mut cmd = cmd.spawn()?;
         trace!(logger, "channel {}: spawn ok: pid {}", id, cmd.id());
         let fds = (
             file_from_command::<PipeWrite, _>(cmd.stdin.take()),
@@ -906,10 +903,7 @@ impl ServerClipboardChannel {
         }
         cmd.stderr(Stdio::null());
         trace!(logger, "channel {}: spawn {:?}", id, cmd);
-        let mut cmd = match cmd.spawn() {
-            Ok(cmd) => cmd,
-            Err(e) => return Err(e.into()),
-        };
+        let mut cmd = cmd.spawn()?;
         trace!(logger, "channel {}: spawn ok: pid {}", id, cmd.id());
         let fds = (
             file_from_command::<PipeWrite, _>(cmd.stdin.take()),

--- a/lawn/src/main.rs
+++ b/lawn/src/main.rs
@@ -1022,10 +1022,7 @@ fn dispatch(verbosity: &mut i32, handled: &mut bool) -> Result<(), Error> {
         Some(("mount", m)) => dispatch_mount(config, &matches, m),
         Some(("proxy", m)) => dispatch_proxy(config, &matches, m),
         Some(("run", m)) => dispatch_run(config, &matches, m),
-        Some((a, b)) => {
-            eprintln!("dx: a: {} {:?}", a, b);
-            Ok(())
-        }
+        Some(_) => Ok(()),
         _ => Err(Error::new(ErrorKind::Unimplemented)),
     };
     match (res, format) {

--- a/lawn/src/serializer/script.rs
+++ b/lawn/src/serializer/script.rs
@@ -241,7 +241,7 @@ impl<'de> ScriptDeserializer<'de> {
     }
 
     fn parse_bytes<'a>(&self, src: &'a [u8], offset: usize) -> Result<Cow<'a, [u8]>, Error> {
-        if src.iter().any(|b| *b == b'%') {
+        if src.contains(&b'%') {
             fn parse_hex(a: u8, b: u8, offset: usize) -> Result<u8, Error> {
                 if (a.is_ascii_digit() || (b'a'..=b'f').contains(&a))
                     && (b.is_ascii_digit() || (b'a'..=b'f').contains(&b))

--- a/lawn/src/server.rs
+++ b/lawn/src/server.rs
@@ -1338,7 +1338,7 @@ impl Server {
                     }
                 };
                 let cred;
-                let value: Option<Box<(dyn Any + Send + Sync + 'static)>> = match &*m.kind {
+                let value: Option<Box<dyn Any + Send + Sync + 'static>> = match &*m.kind {
                     "directory" => None,
                     "credential" => {
                         cred = valid_message!(

--- a/lawn/src/store/credential.rs
+++ b/lawn/src/store/credential.rs
@@ -76,7 +76,7 @@ pub trait CredentialBackendHandle {
     ) -> Result<(), protocol::Error>;
     fn delete(&self) -> Result<(), protocol::Error>;
     fn meta(&self) -> Option<Cow<'_, BTreeMap<Bytes, Value>>>;
-    fn body(&self) -> Result<Option<Box<(dyn Any + Send + Sync + 'static)>>, protocol::Error>;
+    fn body(&self) -> Result<Option<Box<dyn Any + Send + Sync + 'static>>, protocol::Error>;
     fn create(
         self: Arc<Self>,
         path: Option<Bytes>,

--- a/lawn/src/store/credential/git.rs
+++ b/lawn/src/store/credential/git.rs
@@ -141,10 +141,7 @@ impl CommandCredentialBackend for GitCredentialBackend {
         cmd.stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .stderr(Stdio::inherit());
-        let mut child = match cmd.spawn() {
-            Ok(child) => child,
-            Err(e) => return Err(e.into()),
-        };
+        let mut child = cmd.spawn()?;
         let (stdin, stdout) = (child.stdin.take().unwrap(), child.stdout.take().unwrap());
         let proto = GitProtocolHandler::new(
             Arc::new(Mutex::new(stdout)),

--- a/lawn/src/store/credential/helpers.rs
+++ b/lawn/src/store/credential/helpers.rs
@@ -605,6 +605,7 @@ pub trait CommandCredentialBackend {
         id: StoreSelectorID,
         handle: Arc<dyn CredentialBackendHandle + Send + Sync>,
     );
+    #[allow(dead_code)]
     fn get_handle(
         self: Arc<Self>,
         id: StoreSelectorID,

--- a/lawn/src/store/credential/memory.rs
+++ b/lawn/src/store/credential/memory.rs
@@ -768,7 +768,7 @@ impl CommandCredentialBackend for MemoryCredentialBackend {
                 components.pop();
                 let handle: Arc<dyn CredentialBackendHandle + Send + Sync> =
                     if let VaultEntry::Credential(c) = entry {
-                        components.extend((&[name.clone()] as &[Bytes]).iter().cloned());
+                        components.extend((std::slice::from_ref(name) as &[Bytes]).iter().cloned());
                         let path = StorePath::from_components(&components)
                             .unwrap()
                             .into_inner();

--- a/lawn/src/store/credential/memory.rs
+++ b/lawn/src/store/credential/memory.rs
@@ -62,7 +62,7 @@ impl VaultContainer for VaultDirectory {
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(untagged)]
 pub(super) enum VaultEntry {
-    Credential(Credential),
+    Credential(Box<Credential>),
     Directory(VaultDirectory),
 }
 
@@ -357,7 +357,7 @@ impl MemoryCredentialBackend {
             match entry {
                 VaultEntry::Credential(c) if req.matches(c) => {
                     let path = format_bytes!(b"{}{}", path.as_ref(), name.as_ref());
-                    return Ok(Some((c.clone(), path.into())));
+                    return Ok(Some(((**c).clone(), path.into())));
                 }
                 VaultEntry::Credential(_) => continue,
                 VaultEntry::Directory(d) => {
@@ -632,18 +632,18 @@ impl CommandCredentialBackend for MemoryCredentialBackend {
         match (overwrite, create, entries.entry(last_item)) {
             (true, _, Entry::Occupied(mut e)) => match (e.get_mut(), create) {
                 (VaultEntry::Credential(ref mut c), _) => {
-                    *c = cred.clone();
+                    **c = (*cred).clone();
                     Ok(path)
                 }
                 (VaultEntry::Directory(d), true) => {
                     d.entries
-                        .insert(cred.id(), VaultEntry::Credential(cred.clone()));
+                        .insert(cred.id(), VaultEntry::Credential(Box::new((*cred).clone())));
                     Ok(path)
                 }
                 (VaultEntry::Directory(_), false) => Err(CredentialParserError::NoSuchHandle),
             },
             (_, true, Entry::Vacant(e)) => {
-                e.insert(VaultEntry::Credential(cred.clone()));
+                e.insert(VaultEntry::Credential(Box::new((*cred).clone())));
                 Ok(path)
             }
             (_, _, _) => Err(CredentialParserError::NoSuchHandle),
@@ -782,7 +782,7 @@ impl CommandCredentialBackend for MemoryCredentialBackend {
                             id,
                             path,
                             this.clone(),
-                            c.clone(),
+                            (**c).clone(),
                         ))
                     } else {
                         components.extend(
@@ -912,7 +912,7 @@ impl CommandCredentialBackend for MemoryCredentialBackend {
             .map_err(|_| ResponseCode::NotFound)?
             .ok_or(ResponseCode::NotFound)?;
         if let Some(VaultEntry::Credential(ref c)) = cont.entries().get(&last) {
-            let cse: CredentialStoreElement = c.into();
+            let cse: CredentialStoreElement = (*c).as_ref().into();
             Ok(Some(Box::new(cse)))
         } else {
             Ok(None)

--- a/lawn/src/store/credential/memory.rs
+++ b/lawn/src/store/credential/memory.rs
@@ -95,17 +95,12 @@ impl VaultContainer for Vault {
     }
 }
 
-#[derive(Debug, Copy, Clone)]
+#[derive(Default, Debug, Copy, Clone)]
 enum AuthenticationState {
+    #[default]
     Start,
     SentKeyboardInteractivePrompt,
     Authenticated,
-}
-
-impl Default for AuthenticationState {
-    fn default() -> Self {
-        Self::Start
-    }
 }
 
 pub(super) struct LockableData {

--- a/lawn/src/template.rs
+++ b/lawn/src/template.rs
@@ -60,7 +60,7 @@ impl ExtendedError for Error {
 
 impl Template {
     pub fn new(s: &[u8]) -> Template {
-        let expansion = s.iter().any(|&c| c == b'%');
+        let expansion = s.contains(&b'%');
         Template {
             text: s.to_vec().into(),
             needs_expansion: expansion,


### PR DESCRIPTION
When we were using Clap 2.32, we needed to disable the standard features because we couldn't upgrade and there was a dependency on the insecure `atty` crate.  However, now that we're using Clap 4.0, we don't have that dependency any more and we want builtin help handling, which is part of the standard features.  Revert back to the default features in this case.

In addition, perform several cleanups for Clippy to pass.
