### PR TITLE
Cargo.lock: update `bytes` to 1.11.1 for CVE-2026-25541

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -92,9 +92,9 @@ dependencies = [
 
 [[package]]
 name = "bytes"
-version = "1.4.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 dependencies = [
  "serde",
 ]


### PR DESCRIPTION
This resolves a potential integer overflow which might lead to out-of-bound writes.