### PR TITLE
Update rand to 0.8.6 for GHSA-cq8v-f236-94qc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -661,9 +661,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha",


### PR DESCRIPTION
Older versions of the rand crate could cause undefined behaviour in some cases which are not relevant to us.  Update it nonetheless to address this possible source of unsoundness.